### PR TITLE
set debug flags based on build type (configuration) (fixes #5)

### DIFF
--- a/deps/spidershim/build-spidermonkey.sh
+++ b/deps/spidershim/build-spidermonkey.sh
@@ -13,8 +13,12 @@ if test -z "$AUTOCONF"; then
   exit 1
 fi
 
+if test "$BUILDTYPE" = "Debug"; then
+  DEBUG_FLAGS="--enable-debug --disable-optimize"
+fi
+
 test -d build || mkdir build
 cd build
 # First try running Make.  If configure has changed, it will fail, so
 # we'll fall back to configure && make.
-make || (cd ../spidermonkey/js/src && $AUTOCONF && cd - && ../spidermonkey/js/src/configure --disable-shared-js --disable-export-js --disable-js-shell --enable-debug --disable-optimize && make)
+make || (cd ../spidermonkey/js/src && $AUTOCONF && cd - && ../spidermonkey/js/src/configure --disable-shared-js --disable-export-js --disable-js-shell $DEBUG_FLAGS && make)


### PR DESCRIPTION
Gyp sets $BUILDTYPE to the build configuration name (Release, Debug), and this sets SpiderMonkey's debug flags (--enable-debug, --disable-optimize) based on that variable. So it should build with these flags when you configure Gyp to also build debug via `./configure --enable-engine=spidermonkey --debug`. But I haven't yet gotten Gyp to actually do a debug build yet, so I can't confirm that it works.
