### PR TITLE
ignore the build-type-specific dirs

### DIFF
--- a/deps/spidershim/.gitignore
+++ b/deps/spidershim/.gitignore
@@ -1,1 +1,2 @@
-build
+build-debug
+build-opt


### PR DESCRIPTION
Builds build in build-opt or build-debug now, so this updates the SpiderShim-specific .gitignore file to ignore those dirs.
