### PR TITLE
implement String::NewFromOneByte and String::NewFromTwoByte

### DIFF
--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -90,6 +90,42 @@ MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, const char* data,
   return internal::Local<String>::New(isolate, strVal);
 }
 
+MaybeLocal<String> String::NewFromOneByte(Isolate* isolate, const uint8_t* data,
+                                          v8::NewStringType type, int length) {
+  assert(type == v8::NewStringType::kNormal); // TODO: Add support for interned strings
+  JSContext* cx = JSContextFromIsolate(isolate);
+  JS::RootedString str(cx, length >= 0 ?
+    JS_NewStringCopyN(cx, reinterpret_cast<const char*>(data), length) :
+    JS_NewStringCopyZ(cx, reinterpret_cast<const char*>(data)));
+  if (!str) {
+    return MaybeLocal<String>();
+  }
+  JS::Value strVal;
+  strVal.setString(str);
+  return internal::Local<String>::New(isolate, strVal);
+}
+
+MaybeLocal<String> String::NewFromTwoByte(Isolate* isolate, const uint16_t* data,
+                                          v8::NewStringType type, int length) {
+  assert(type == v8::NewStringType::kNormal); // TODO: Add support for interned strings
+  JSContext* cx = JSContextFromIsolate(isolate);
+  JS::RootedString str(cx, length >= 0 ?
+    JS_NewUCStringCopyN(cx, reinterpret_cast<const char16_t*>(data), length) :
+    JS_NewUCStringCopyZ(cx, reinterpret_cast<const char16_t*>(data)));
+  if (!str) {
+    return MaybeLocal<String>();
+  }
+  JS::Value strVal;
+  strVal.setString(str);
+  return internal::Local<String>::New(isolate, strVal);
+}
+
+Local<String> String::NewFromTwoByte(Isolate* isolate, const uint16_t* data,
+                                     NewStringType type, int length) {
+  return NewFromTwoByte(isolate, data, static_cast<v8::NewStringType>(type),
+                        length).FromMaybe(Local<String>());
+}
+
 String* String::Cast(v8::Value* obj) {
   assert(reinterpret_cast<JS::Value*>(obj)->isString());
   return static_cast<String*>(obj);

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -828,16 +828,6 @@ TEST(SpiderShim, String) {
   const uint16_t utf16Data[] = { 0x02E4, 0x0064, 0x12E4, 0x0030, 0x3045, 0x0000 };
   const unsigned char utf8Data[] = { 0xCB, 0xA4, 0x64, 0xE1, 0x8B, 0xA4, 0x30, 0xE3, 0x81, 0x85, 0x00 };
 
-  // This test currently fails because String::NewFromUtf8 interprets its input
-  // as Latin-1 rather than UTF-8.
-  Local<String> fromUtf8Str =
-    String::NewFromUtf8(engine.isolate(), reinterpret_cast<const char*>(utf8Data), NewStringType::kNormal).
-      ToLocalChecked();
-  EXPECT_EQ(5, fromUtf8Str->Length());
-  EXPECT_EQ(10, fromUtf8Str->Utf8Length());
-  String::Value fromUtf8Val(fromUtf8Str);
-  EXPECT_EQ(0, memcmp(*fromUtf8Val, utf16Data, sizeof(*utf16Data)));
-
   Local<String> fromTwoByteStr =
     String::NewFromTwoByte(engine.isolate(), utf16Data, NewStringType::kNormal).
       ToLocalChecked();

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -795,6 +795,56 @@ TEST(SpiderShim, String) {
   EXPECT_STREQ(*utf8Concat, "foobarbaz");
   EXPECT_TRUE(foobar->ToObject()->IsStringObject());
   EXPECT_EQ(StringObject::Cast(*foobar->ToObject())->ValueOf()->Length(), 6);
+
+  const uint8_t asciiData[] = { 0x4F, 0x68, 0x61, 0x69, 0x00 }; // "Ohai"
+
+  Local<String> asciiStr =
+    String::NewFromOneByte(engine.isolate(), asciiData, NewStringType::kNormal).
+      ToLocalChecked();
+  EXPECT_EQ(4, asciiStr->Length());
+  EXPECT_EQ(4, asciiStr->Utf8Length());
+  String::Value asciiVal(asciiStr);
+  EXPECT_EQ(0, memcmp(*asciiVal, asciiData, sizeof(*asciiData)));
+
+  const uint8_t latin1Data[] = { 0xD3, 0x68, 0xE3, 0xEF, 0x00 }; // "Óhãï"
+
+  Local<String> latin1Str =
+    String::NewFromOneByte(engine.isolate(), latin1Data, NewStringType::kNormal).
+      ToLocalChecked();
+  EXPECT_EQ(4, latin1Str->Length());
+  EXPECT_EQ(7, latin1Str->Utf8Length());
+  String::Value latin1Val(latin1Str);
+  EXPECT_EQ(0, memcmp(*latin1Val, latin1Data, sizeof(*latin1Data)));
+
+  // A five character string (u"ˤdዤ0ぅ", from V8's test-strings.cc) in UTF-16
+  // and UTF-8 bytes.
+  // UTF-16 -> UTF-8
+  // ------    -----
+  // U+02E4 -> CB A4
+  // U+0064 -> 64
+  // U+12E4 -> E1 8B A4
+  // U+0030 -> 30
+  // U+3045 -> E3 81 85
+  const uint16_t utf16Data[] = { 0x02E4, 0x0064, 0x12E4, 0x0030, 0x3045, 0x0000 };
+  const unsigned char utf8Data[] = { 0xCB, 0xA4, 0x64, 0xE1, 0x8B, 0xA4, 0x30, 0xE3, 0x81, 0x85, 0x00 };
+
+  // This test currently fails because String::NewFromUtf8 interprets its input
+  // as Latin-1 rather than UTF-8.
+  Local<String> fromUtf8Str =
+    String::NewFromUtf8(engine.isolate(), reinterpret_cast<const char*>(utf8Data), NewStringType::kNormal).
+      ToLocalChecked();
+  EXPECT_EQ(5, fromUtf8Str->Length());
+  EXPECT_EQ(10, fromUtf8Str->Utf8Length());
+  String::Value fromUtf8Val(fromUtf8Str);
+  EXPECT_EQ(0, memcmp(*fromUtf8Val, utf16Data, sizeof(*utf16Data)));
+
+  Local<String> fromTwoByteStr =
+    String::NewFromTwoByte(engine.isolate(), utf16Data, NewStringType::kNormal).
+      ToLocalChecked();
+  EXPECT_EQ(5, fromTwoByteStr->Length());
+  EXPECT_EQ(10, fromTwoByteStr->Utf8Length());
+  String::Value fromTwoByteVal(fromTwoByteStr);
+  EXPECT_EQ(0, memcmp(*fromTwoByteVal, utf16Data, sizeof(*utf16Data)));
 }
 
 TEST(SpiderShim, ToObject) {


### PR DESCRIPTION
This PR implements _String::NewFromOneByte_ and _String::NewFromTwoByte_. It also adds a test that demonstrates a bug in _String::NewFromUtf8_, which currently uses _JS_NewStringCopyN_ and _JS_NewStringCopyZ_ to decode the input data, although those functions interpret the data as Latin-1, not UTF-8. (I'm not yet sure what the fix is, but I figured it'd still be worth adding a failing test for the bug, so we can confirm the fix once we land it.)
