### PR TITLE
implement String::NewExternalTwoByte

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -113,6 +113,7 @@ struct ExternalArrayData;
 namespace internal {
 class RootStore;
 template <class T> class Local;
+struct ExternalStringFinalizer;
 }
 
 enum PropertyAttribute {
@@ -1171,7 +1172,7 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend struct ExternalStringFinalizer;
+    friend struct internal::ExternalStringFinalizer;
   };
 
   /**

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -106,9 +106,6 @@ template <class T, class M = NonCopyablePersistentTraits<T> > class Persistent;
 template <typename T> class FunctionCallbackInfo;
 template <typename T> class PropertyCallbackInfo;
 
-namespace internal {
-class Heap;
-}  // namespace internal
 class JitCodeEvent;
 class RetainedObjectInfo;
 struct ExternalArrayData;
@@ -1174,7 +1171,6 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend class v8::internal::Heap;
     friend struct ExternalStringFinalizer;
   };
 

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -106,6 +106,9 @@ template <class T, class M = NonCopyablePersistentTraits<T> > class Persistent;
 template <typename T> class FunctionCallbackInfo;
 template <typename T> class PropertyCallbackInfo;
 
+namespace internal {
+class Heap;
+}  // namespace internal
 class JitCodeEvent;
 class RetainedObjectInfo;
 struct ExternalArrayData;
@@ -1149,18 +1152,85 @@ class V8_EXPORT String : public Name {
   bool IsExternal() const { return false; }
   bool IsExternalOneByte() const { return false; }
 
-  class V8_EXPORT ExternalOneByteStringResource {
+  class V8_EXPORT ExternalStringResourceBase {  // NOLINT
    public:
-    virtual ~ExternalOneByteStringResource() {}
-    virtual const char *data() const = 0;
-    virtual size_t length() const = 0;
+    virtual ~ExternalStringResourceBase() {}
+
+    virtual bool IsCompressible() const { return false; }
+
+   protected:
+    ExternalStringResourceBase() {}
+
+    /**
+     * Internally V8 will call this Dispose method when the external string
+     * resource is no longer needed. The default implementation will use the
+     * delete operator. This method can be overridden in subclasses to
+     * control how allocated external string resources are disposed.
+     */
+    virtual void Dispose() { delete this; }
+
+   private:
+    // Disallow copying and assigning.
+    ExternalStringResourceBase(const ExternalStringResourceBase&);
+    void operator=(const ExternalStringResourceBase&);
+
+    friend class v8::internal::Heap;
+    friend struct ExternalStringFinalizer;
   };
 
-  class V8_EXPORT ExternalStringResource {
+  /**
+   * An ExternalStringResource is a wrapper around a two-byte string
+   * buffer that resides outside V8's heap. Implement an
+   * ExternalStringResource to manage the life cycle of the underlying
+   * buffer.  Note that the string data must be immutable.
+   */
+  class V8_EXPORT ExternalStringResource
+      : public ExternalStringResourceBase {
    public:
+    /**
+     * Override the destructor to manage the life cycle of the underlying
+     * buffer.
+     */
     virtual ~ExternalStringResource() {}
+
+    /**
+     * The string data from the underlying buffer.
+     */
     virtual const uint16_t* data() const = 0;
+
+    /**
+     * The length of the string. That is, the number of two-byte characters.
+     */
     virtual size_t length() const = 0;
+
+   protected:
+    ExternalStringResource() {}
+  };
+
+  /**
+   * An ExternalOneByteStringResource is a wrapper around an one-byte
+   * string buffer that resides outside V8's heap. Implement an
+   * ExternalOneByteStringResource to manage the life cycle of the
+   * underlying buffer.  Note that the string data must be immutable
+   * and that the data must be Latin-1 and not UTF-8, which would require
+   * special treatment internally in the engine and do not allow efficient
+   * indexing.  Use String::New or convert to 16 bit data for non-Latin1.
+   */
+
+  class V8_EXPORT ExternalOneByteStringResource
+      : public ExternalStringResourceBase {
+   public:
+    /**
+     * Override the destructor to manage the life cycle of the underlying
+     * buffer.
+     */
+    virtual ~ExternalOneByteStringResource() {}
+    /** The string data from the underlying buffer.*/
+    virtual const char* data() const = 0;
+    /** The number of Latin-1 characters in the string.*/
+    virtual size_t length() const = 0;
+   protected:
+    ExternalOneByteStringResource() {}
   };
 
   ExternalStringResource* GetExternalStringResource() const { return nullptr; }

--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -150,8 +150,6 @@ MaybeLocal<String> String::NewExternalTwoByte(Isolate* isolate,
     return MaybeLocal<String>();
   }
 
-  fin->finalize = internal::ExternalStringFinalizer::FinalizeExternalString;
-
   JS::RootedString str(cx,
     JS_NewExternalString(cx, reinterpret_cast<const char16_t*>(resource->data()),
                          resource->length(), fin.release()));
@@ -225,7 +223,9 @@ JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, si
 }
 
 ExternalStringFinalizer::ExternalStringFinalizer(String::ExternalStringResource* resource)
-  : resource_(resource) {}
+  : resource_(resource) {
+  this->finalize = FinalizeExternalString;
+}
 
 void ExternalStringFinalizer::dispose() {
   // Based on V8's Heap::FinalizeExternalString.

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -31,6 +31,7 @@ JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, si
 struct ExternalStringFinalizer : JSStringFinalizer {
   ExternalStringFinalizer(String::ExternalStringResource* resource);
   String::ExternalStringResource* resource_;
+  static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
   void dispose();
   // XXX Define finalize() here as a struct member instead of assigning it
   // after instantiation.

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -28,5 +28,13 @@ namespace internal {
 
 JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, size_t* length = nullptr);
 
+struct ExternalStringFinalizer : JSStringFinalizer {
+  ExternalStringFinalizer(String::ExternalStringResource* resource);
+  String::ExternalStringResource* resource_;
+  void dispose();
+  // XXX Define finalize() here as a struct member instead of assigning it
+  // after instantiation.
+};
+
 }
 }

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -778,6 +778,24 @@ TEST(SpiderShim, Date) {
   EXPECT_EQ(time, Date::Cast(*date.ToLocalChecked()->ToObject())->ValueOf());
 }
 
+namespace {
+
+class TestExternalStringResource : public String::ExternalStringResource {
+  public:
+    TestExternalStringResource(const uint16_t* source, size_t length)
+        : data_(source), length_(length) {}
+    ~TestExternalStringResource() {
+      // XXX Check that we get called when the string is finalized.
+    }
+    const uint16_t* data() const override { return data_; }
+    size_t length() const override { return length_; }
+  private:
+    const uint16_t* data_;
+    size_t length_;
+};
+
+}  // namespace
+
 TEST(SpiderShim, String) {
   V8Engine engine;
 
@@ -857,6 +875,16 @@ TEST(SpiderShim, String) {
   String::Utf8Value fromUtf8Utf8Val(fromUtf8Str);
   EXPECT_EQ(0, memcmp(*fromUtf8Val, utf16Data, sizeof(*utf16Data)));
   EXPECT_EQ(0, memcmp(*fromUtf8Utf8Val, utf8Data, sizeof(*utf8Data)));
+
+  TestExternalStringResource* testResource =
+    new TestExternalStringResource(utf16Data, (sizeof(utf16Data)/sizeof(*utf16Data) - 1));
+  Local<String> externalStr = String::NewExternalTwoByte(engine.isolate(), testResource).ToLocalChecked();
+  EXPECT_EQ(5, externalStr->Length());
+  EXPECT_EQ(10, externalStr->Utf8Length());
+  String::Value externalVal(externalStr);
+  String::Utf8Value externalUtf8Val(externalStr);
+  EXPECT_EQ(0, memcmp(*externalVal, utf16Data, sizeof(*utf16Data)));
+  EXPECT_EQ(0, memcmp(*externalUtf8Val, utf8Data, sizeof(*utf8Data)));
 }
 
 TEST(SpiderShim, ToObject) {

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -780,12 +780,14 @@ TEST(SpiderShim, Date) {
 
 namespace {
 
+bool externalStringResourceDestructorCalled = false;
+
 class TestExternalStringResource : public String::ExternalStringResource {
   public:
     TestExternalStringResource(const uint16_t* source, size_t length)
         : data_(source), length_(length) {}
     ~TestExternalStringResource() {
-      // XXX Check that we get called when the string is finalized.
+      externalStringResourceDestructorCalled = true;
     }
     const uint16_t* data() const override { return data_; }
     size_t length() const override { return length_; }
@@ -885,6 +887,13 @@ TEST(SpiderShim, String) {
   String::Utf8Value externalUtf8Val(externalStr);
   EXPECT_EQ(0, memcmp(*externalVal, utf16Data, sizeof(*utf16Data)));
   EXPECT_EQ(0, memcmp(*externalUtf8Val, utf8Data, sizeof(*utf8Data)));
+}
+
+// Other tests of external strings live in the String test function above.
+// This just checks that an external string resource's destructor was called
+// when the string was finalized.
+TEST(SpiderShim, ExternalStringResourceDestructorCalled) {
+  EXPECT_TRUE(externalStringResourceDestructorCalled);
 }
 
 TEST(SpiderShim, ToObject) {


### PR DESCRIPTION
This branch implements String::NewExternalTwoByte by translating between the V8 API, which represents an external string as an ExternalStringResource instance whose destructor frees its resources; and the SpiderMonkey API, which registers a JSStringFinalizer struct for the string whose finalize() method does that work.

All examples of JSStringFinalizer in Gecko are static, but this implementation needs to associate them with arbitrary ExternalStringResource instances, so it extends JSStringFinalizer to have a resource_ member and instantiate the struct dynamically. Presumably this is the use case for which [bug 776000](https://bugzilla.mozilla.org/show_bug.cgi?id=776000) was filed, and this implementation may be somewhat akin to [comment 8 on that bug](https://bugzilla.mozilla.org/show_bug.cgi?id=776000#c8).

I'd love to get design input in additional to code review, as it isn't clear to me if this is the best possible way to translate between the two APIs.

Note: the v8.h changes simply revert changes made in deps/chakrashim/include/v8.h, so ExternalStringResource and ExternalStringResourceBase are defined the way they are in deps/v8/include/v8.h. [ChakraShim's version of String::NewExternalTwoByte](https://github.com/mozilla/spidernode/blob/e0ca6e7379230698bf0434b8028a98caabe06a8c/deps/chakrashim/src/v8string.cc#L315-L328) doesn't currently manage external strings, it simply copies their data and deletes them. Which is presumably why [this ChakraShim comment](https://github.com/mozilla/spidernode/blob/e0ca6e7379230698bf0434b8028a98caabe06a8c/src/string_bytes.cc#L79-L81) warns against accessing a string after passing it to String::NewExternal.

Also, the test could be more thorough, although I'm unsure how to expand it. I haven't found much existing code for testing external strings (although they're used incidentally to test other APIs).
