### PR TITLE
implement String::NewExternalOneByte

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -113,6 +113,7 @@ struct ExternalArrayData;
 namespace internal {
 class RootStore;
 template <class T> class Local;
+struct ExternalStringFinalizer;
 }
 
 enum PropertyAttribute {
@@ -1171,7 +1172,7 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend struct ExternalStringFinalizer;
+    friend struct internal::ExternalStringFinalizer;
   };
 
   /**

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -106,9 +106,6 @@ template <class T, class M = NonCopyablePersistentTraits<T> > class Persistent;
 template <typename T> class FunctionCallbackInfo;
 template <typename T> class PropertyCallbackInfo;
 
-namespace internal {
-class Heap;
-}  // namespace internal
 class JitCodeEvent;
 class RetainedObjectInfo;
 struct ExternalArrayData;
@@ -1174,7 +1171,6 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend class v8::internal::Heap;
     friend struct ExternalStringFinalizer;
   };
 

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -113,7 +113,9 @@ struct ExternalArrayData;
 namespace internal {
 class RootStore;
 template <class T> class Local;
-struct ExternalStringFinalizerBase;
+template <typename T> struct ExternalStringFinalizerBase;
+struct ExternalStringFinalizer;
+struct ExternalOneByteStringFinalizer;
 }
 
 enum PropertyAttribute {
@@ -1172,7 +1174,8 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend struct internal::ExternalStringFinalizerBase;
+    friend struct internal::ExternalStringFinalizerBase<internal::ExternalStringFinalizer>;
+    friend struct internal::ExternalStringFinalizerBase<internal::ExternalOneByteStringFinalizer>;
   };
 
   /**

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -106,6 +106,9 @@ template <class T, class M = NonCopyablePersistentTraits<T> > class Persistent;
 template <typename T> class FunctionCallbackInfo;
 template <typename T> class PropertyCallbackInfo;
 
+namespace internal {
+class Heap;
+}  // namespace internal
 class JitCodeEvent;
 class RetainedObjectInfo;
 struct ExternalArrayData;
@@ -1149,18 +1152,85 @@ class V8_EXPORT String : public Name {
   bool IsExternal() const { return false; }
   bool IsExternalOneByte() const { return false; }
 
-  class V8_EXPORT ExternalOneByteStringResource {
+  class V8_EXPORT ExternalStringResourceBase {  // NOLINT
    public:
-    virtual ~ExternalOneByteStringResource() {}
-    virtual const char *data() const = 0;
-    virtual size_t length() const = 0;
+    virtual ~ExternalStringResourceBase() {}
+
+    virtual bool IsCompressible() const { return false; }
+
+   protected:
+    ExternalStringResourceBase() {}
+
+    /**
+     * Internally V8 will call this Dispose method when the external string
+     * resource is no longer needed. The default implementation will use the
+     * delete operator. This method can be overridden in subclasses to
+     * control how allocated external string resources are disposed.
+     */
+    virtual void Dispose() { delete this; }
+
+   private:
+    // Disallow copying and assigning.
+    ExternalStringResourceBase(const ExternalStringResourceBase&);
+    void operator=(const ExternalStringResourceBase&);
+
+    friend class v8::internal::Heap;
+    friend struct ExternalStringFinalizer;
   };
 
-  class V8_EXPORT ExternalStringResource {
+  /**
+   * An ExternalStringResource is a wrapper around a two-byte string
+   * buffer that resides outside V8's heap. Implement an
+   * ExternalStringResource to manage the life cycle of the underlying
+   * buffer.  Note that the string data must be immutable.
+   */
+  class V8_EXPORT ExternalStringResource
+      : public ExternalStringResourceBase {
    public:
+    /**
+     * Override the destructor to manage the life cycle of the underlying
+     * buffer.
+     */
     virtual ~ExternalStringResource() {}
+
+    /**
+     * The string data from the underlying buffer.
+     */
     virtual const uint16_t* data() const = 0;
+
+    /**
+     * The length of the string. That is, the number of two-byte characters.
+     */
     virtual size_t length() const = 0;
+
+   protected:
+    ExternalStringResource() {}
+  };
+
+  /**
+   * An ExternalOneByteStringResource is a wrapper around an one-byte
+   * string buffer that resides outside V8's heap. Implement an
+   * ExternalOneByteStringResource to manage the life cycle of the
+   * underlying buffer.  Note that the string data must be immutable
+   * and that the data must be Latin-1 and not UTF-8, which would require
+   * special treatment internally in the engine and do not allow efficient
+   * indexing.  Use String::New or convert to 16 bit data for non-Latin1.
+   */
+
+  class V8_EXPORT ExternalOneByteStringResource
+      : public ExternalStringResourceBase {
+   public:
+    /**
+     * Override the destructor to manage the life cycle of the underlying
+     * buffer.
+     */
+    virtual ~ExternalOneByteStringResource() {}
+    /** The string data from the underlying buffer.*/
+    virtual const char* data() const = 0;
+    /** The number of Latin-1 characters in the string.*/
+    virtual size_t length() const = 0;
+   protected:
+    ExternalOneByteStringResource() {}
   };
 
   ExternalStringResource* GetExternalStringResource() const { return nullptr; }

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -113,7 +113,7 @@ struct ExternalArrayData;
 namespace internal {
 class RootStore;
 template <class T> class Local;
-struct ExternalStringFinalizer;
+struct ExternalStringFinalizerBase;
 }
 
 enum PropertyAttribute {
@@ -1172,7 +1172,7 @@ class V8_EXPORT String : public Name {
     ExternalStringResourceBase(const ExternalStringResourceBase&);
     void operator=(const ExternalStringResourceBase&);
 
-    friend struct internal::ExternalStringFinalizer;
+    friend struct internal::ExternalStringFinalizerBase;
   };
 
   /**

--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -201,6 +201,11 @@ Local<String> String::NewExternal(Isolate* isolate,
   return NewExternalTwoByte(isolate, resource).FromMaybe(Local<String>());
 }
 
+Local<String> String::NewExternal(Isolate* isolate,
+                                  ExternalOneByteStringResource* resource) {
+  return NewExternalOneByte(isolate, resource).FromMaybe(Local<String>());
+}
+
 String* String::Cast(v8::Value* obj) {
   assert(reinterpret_cast<JS::Value*>(obj)->isString());
   return static_cast<String*>(obj);

--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -161,6 +161,41 @@ MaybeLocal<String> String::NewExternalTwoByte(Isolate* isolate,
   return internal::Local<String>::New(isolate, strVal);
 }
 
+MaybeLocal<String> String::NewExternalOneByte(Isolate* isolate,
+                                              ExternalOneByteStringResource* resource) {
+  JSContext* cx = JSContextFromIsolate(isolate);
+
+  auto fin = mozilla::MakeUnique<internal::ExternalOneByteStringFinalizer>(resource);
+  if (!fin) {
+    return MaybeLocal<String>();
+  }
+
+  // SpiderMonkey doesn't have a one-byte variant of JS_NewExternalString, so we
+  // inflate the external string data to its two-byte equivalent.  According to
+  // https://github.com/mozilla/spidernode/blob/7466b2f/deps/v8/include/v8.h#L2252-L2260
+  // the external string data is immutable, so there's no risk of it changing
+  // after we inflate it.  But we do need to ensure that the inflated data gets
+  // deleted when the string is finalized, which FinalizeExternalString does.
+  size_t length = resource->length();
+  JS::UniqueTwoByteChars data(js_pod_malloc<char16_t>(length + 1));
+  if (!data) {
+    return MaybeLocal<String>();
+  }
+  const char* oneByteData = resource->data();
+  for (size_t i = 0; i < length; ++i)
+      data[i] = (unsigned char) oneByteData[i];
+  data[length] = 0;
+
+  JS::RootedString str(cx, JS_NewExternalString(cx, data.release(), length, fin.release()));
+  if (!str) {
+    return MaybeLocal<String>();
+  }
+
+  JS::Value strVal;
+  strVal.setString(str);
+  return internal::Local<String>::New(isolate, strVal);
+}
+
 Local<String> String::NewExternal(Isolate* isolate,
                                   ExternalStringResource* resource) {
   return NewExternalTwoByte(isolate, resource).FromMaybe(Local<String>());
@@ -222,12 +257,10 @@ JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, si
   return buffer;
 }
 
-ExternalStringFinalizer::ExternalStringFinalizer(String::ExternalStringResource* resource)
-  : resource_(resource) {
-  this->finalize = FinalizeExternalString;
-}
+ExternalStringFinalizerBase::ExternalStringFinalizerBase(String::ExternalStringResourceBase* resource)
+  : resource_(resource) {}
 
-void ExternalStringFinalizer::dispose() {
+void ExternalStringFinalizerBase::dispose() {
   // Based on V8's Heap::FinalizeExternalString.
 
   // Dispose of the C++ object if it has not already been disposed.
@@ -241,9 +274,29 @@ void ExternalStringFinalizer::dispose() {
   delete this;
 };
 
+ExternalStringFinalizer::ExternalStringFinalizer(String::ExternalStringResourceBase* resource)
+  : ExternalStringFinalizerBase(resource) {
+  this->finalize = FinalizeExternalString;
+}
+
 void ExternalStringFinalizer::FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars) {
-  const_cast<internal::ExternalStringFinalizer*>(
-    static_cast<const internal::ExternalStringFinalizer*>(fin))->dispose();
+  const_cast<internal::ExternalStringFinalizerBase*>(
+    static_cast<const internal::ExternalStringFinalizerBase*>(fin))->dispose();
+}
+
+ExternalOneByteStringFinalizer::ExternalOneByteStringFinalizer(String::ExternalStringResourceBase* resource)
+  : ExternalStringFinalizerBase(resource) {
+  this->finalize = FinalizeExternalString;
+}
+
+void ExternalOneByteStringFinalizer::FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars) {
+  const_cast<internal::ExternalStringFinalizerBase*>(
+    static_cast<const internal::ExternalStringFinalizerBase*>(fin))->dispose();
+
+  // NewExternalOneByte made a two-byte copy of the data in the resource,
+  // and this is that copy. The resource will handle deleting its original
+  // data, but we have to delete this copy.
+  delete chars;
 }
 
 }

--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -150,8 +150,6 @@ MaybeLocal<String> String::NewExternalTwoByte(Isolate* isolate,
     return MaybeLocal<String>();
   }
 
-  fin->finalize = internal::ExternalStringFinalizer::FinalizeExternalString;
-
   JS::RootedString str(cx,
     JS_NewExternalString(cx, reinterpret_cast<const char16_t*>(resource->data()),
                          resource->length(), fin.release()));
@@ -225,7 +223,9 @@ JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, si
 }
 
 ExternalStringFinalizer::ExternalStringFinalizer(String::ExternalStringResource* resource)
-  : resource_(resource) {}
+  : resource_(resource) {
+  this->finalize = FinalizeExternalString;
+}
 
 void ExternalStringFinalizer::dispose() {
   // Based on V8's Heap::FinalizeExternalString.

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -31,6 +31,7 @@ JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, si
 struct ExternalStringFinalizer : JSStringFinalizer {
   ExternalStringFinalizer(String::ExternalStringResource* resource);
   String::ExternalStringResource* resource_;
+  static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
   void dispose();
   // XXX Define finalize() here as a struct member instead of assigning it
   // after instantiation.

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -28,5 +28,13 @@ namespace internal {
 
 JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, size_t* length = nullptr);
 
+struct ExternalStringFinalizer : JSStringFinalizer {
+  ExternalStringFinalizer(String::ExternalStringResource* resource);
+  String::ExternalStringResource* resource_;
+  void dispose();
+  // XXX Define finalize() here as a struct member instead of assigning it
+  // after instantiation.
+};
+
 }
 }

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -33,8 +33,6 @@ struct ExternalStringFinalizerBase : JSStringFinalizer {
   ExternalStringFinalizerBase(String::ExternalStringResourceBase* resource);
   String::ExternalStringResourceBase* resource_;
   void dispose();
-  // XXX Define finalize() here as a struct member instead of assigning it
-  // after instantiation.
 };
 
 struct ExternalStringFinalizer : ExternalStringFinalizerBase<ExternalStringFinalizer> {

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -28,6 +28,7 @@ namespace internal {
 
 JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, size_t* length = nullptr);
 
+template<typename T>
 struct ExternalStringFinalizerBase : JSStringFinalizer {
   ExternalStringFinalizerBase(String::ExternalStringResourceBase* resource);
   String::ExternalStringResourceBase* resource_;
@@ -36,12 +37,12 @@ struct ExternalStringFinalizerBase : JSStringFinalizer {
   // after instantiation.
 };
 
-struct ExternalStringFinalizer : ExternalStringFinalizerBase {
+struct ExternalStringFinalizer : ExternalStringFinalizerBase<ExternalStringFinalizer> {
   ExternalStringFinalizer(String::ExternalStringResourceBase* resource);
   static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
 };
 
-struct ExternalOneByteStringFinalizer : ExternalStringFinalizerBase {
+struct ExternalOneByteStringFinalizer : ExternalStringFinalizerBase<ExternalOneByteStringFinalizer> {
   ExternalOneByteStringFinalizer(String::ExternalStringResourceBase* resource);
   static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
 };

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -28,13 +28,22 @@ namespace internal {
 
 JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, size_t* length = nullptr);
 
-struct ExternalStringFinalizer : JSStringFinalizer {
-  ExternalStringFinalizer(String::ExternalStringResource* resource);
-  String::ExternalStringResource* resource_;
-  static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
+struct ExternalStringFinalizerBase : JSStringFinalizer {
+  ExternalStringFinalizerBase(String::ExternalStringResourceBase* resource);
+  String::ExternalStringResourceBase* resource_;
   void dispose();
   // XXX Define finalize() here as a struct member instead of assigning it
   // after instantiation.
+};
+
+struct ExternalStringFinalizer : ExternalStringFinalizerBase {
+  ExternalStringFinalizer(String::ExternalStringResourceBase* resource);
+  static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
+};
+
+struct ExternalOneByteStringFinalizer : ExternalStringFinalizerBase {
+  ExternalOneByteStringFinalizer(String::ExternalStringResourceBase* resource);
+  static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
 };
 
 }

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -778,6 +778,24 @@ TEST(SpiderShim, Date) {
   EXPECT_EQ(time, Date::Cast(*date.ToLocalChecked()->ToObject())->ValueOf());
 }
 
+namespace {
+
+class TestExternalStringResource : public String::ExternalStringResource {
+  public:
+    TestExternalStringResource(const uint16_t* source, size_t length)
+        : data_(source), length_(length) {}
+    ~TestExternalStringResource() {
+      // XXX Check that we get called when the string is finalized.
+    }
+    const uint16_t* data() const override { return data_; }
+    size_t length() const override { return length_; }
+  private:
+    const uint16_t* data_;
+    size_t length_;
+};
+
+}  // namespace
+
 TEST(SpiderShim, String) {
   V8Engine engine;
 
@@ -857,6 +875,16 @@ TEST(SpiderShim, String) {
   String::Utf8Value fromUtf8Utf8Val(fromUtf8Str);
   EXPECT_EQ(0, memcmp(*fromUtf8Val, utf16Data, sizeof(*utf16Data)));
   EXPECT_EQ(0, memcmp(*fromUtf8Utf8Val, utf8Data, sizeof(*utf8Data)));
+
+  TestExternalStringResource* testResource =
+    new TestExternalStringResource(utf16Data, (sizeof(utf16Data)/sizeof(*utf16Data) - 1));
+  Local<String> externalStr = String::NewExternalTwoByte(engine.isolate(), testResource).ToLocalChecked();
+  EXPECT_EQ(5, externalStr->Length());
+  EXPECT_EQ(10, externalStr->Utf8Length());
+  String::Value externalVal(externalStr);
+  String::Utf8Value externalUtf8Val(externalStr);
+  EXPECT_EQ(0, memcmp(*externalVal, utf16Data, sizeof(*utf16Data)));
+  EXPECT_EQ(0, memcmp(*externalUtf8Val, utf8Data, sizeof(*utf8Data)));
 }
 
 TEST(SpiderShim, ToObject) {

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -780,12 +780,14 @@ TEST(SpiderShim, Date) {
 
 namespace {
 
+bool externalStringResourceDestructorCalled = false;
+
 class TestExternalStringResource : public String::ExternalStringResource {
   public:
     TestExternalStringResource(const uint16_t* source, size_t length)
         : data_(source), length_(length) {}
     ~TestExternalStringResource() {
-      // XXX Check that we get called when the string is finalized.
+      externalStringResourceDestructorCalled = true;
     }
     const uint16_t* data() const override { return data_; }
     size_t length() const override { return length_; }
@@ -885,6 +887,13 @@ TEST(SpiderShim, String) {
   String::Utf8Value externalUtf8Val(externalStr);
   EXPECT_EQ(0, memcmp(*externalVal, utf16Data, sizeof(*utf16Data)));
   EXPECT_EQ(0, memcmp(*externalUtf8Val, utf8Data, sizeof(*utf8Data)));
+}
+
+// Other tests of external strings live in the String test function above.
+// This just checks that an external string resource's destructor was called
+// when the string was finalized.
+TEST(SpiderShim, ExternalStringResourceDestructorCalled) {
+  EXPECT_TRUE(externalStringResourceDestructorCalled);
 }
 
 TEST(SpiderShim, ToObject) {


### PR DESCRIPTION
This implements String::NewExternalOneByte. It's based on #49, so it contains the changes on that branch as well. To see only the changes on this branch, view this comparison:

https://github.com/mykmelez/spidernode/compare/string-new-external-two-byte...string-new-external-one-byte
