### PR TITLE
implement String::Write*

### DIFF
--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -244,6 +244,62 @@ Local<String> String::Concat(Handle<String> left, Handle<String> right) {
   return internal::Local<String>::New(isolate, retVal);
 }
 
+int String::Write(uint16_t* buffer, int start, int length, int options) const {
+  return internal::Write(this, reinterpret_cast<char16_t*>(buffer), start, length, options);
+}
+
+int String::WriteOneByte(uint8_t* buffer, int start, int length, int options) const {
+  return internal::Write(this, reinterpret_cast<char*>(buffer), start, length, options);
+}
+
+// Based on String::WriteUtf8 in V8's api.cc.
+int String::WriteUtf8(char* buffer, int capacity, int* numChars, int options) const {
+  bool nullTermination = !(options & NO_NULL_TERMINATION);
+
+  JSContext* cx = JSContextFromIsolate(Isolate::GetCurrent());
+  JSString* thisStr = reinterpret_cast<const JS::Value*>(this)->toString();
+  JSLinearString* linearStr = js::StringToLinearString(cx, thisStr);
+  if (!linearStr) {
+    return 0;
+  }
+
+  // The number of bytes written to the buffer.  DeflateStringToUTF8Buffer
+  // expects its initial value to be the capacity of the buffer, and it uses it
+  // to determine whether/when to abort writing bytes to the buffer.
+  size_t numBytes = (size_t)capacity;
+
+  // The number of Unicode characters written to the buffer. This could be
+  // less than the length of the string, if the buffer isn't big enough to hold
+  // the whole string.
+  if (numChars != nullptr) {
+    *numChars = 0;
+  }
+
+  bool completed = internal::DeflateStringToUTF8Buffer(linearStr, buffer, &numBytes, numChars, options);
+
+  if (completed) {
+    // If the caller requested null termination, but the buffer doesn't have
+    // any more space for it, then disable null termination.
+    if (nullTermination && (size_t)capacity == numBytes) {
+      nullTermination = false;
+    }
+  } else {
+    // Deflation was aborted, so don't null terminate, regardless of what
+    // the caller requested.  Presumably this is because deflation only aborts
+    // when the buffer runs out of space (although it's possible for the buffer
+    // to still have space for null termination in that case, if the abort
+    // happens on a character that deflates to multiple bytes, and the buffer
+    // has at least one free byte, but not enough to hold the whole character).
+    nullTermination = false;
+  }
+
+  if (nullTermination) {
+    buffer[numBytes++] = '\0';
+  }
+
+  return numBytes;
+}
+
 namespace internal {
 
 JS::UniqueTwoByteChars GetFlatString(JSContext* cx, v8::Local<String> source, size_t* length) {
@@ -302,6 +358,180 @@ void ExternalOneByteStringFinalizer::FinalizeExternalString(const JSStringFinali
   // and this is that copy. The resource will handle deleting its original
   // data, but we have to delete this copy.
   delete chars;
+}
+
+// Based on WriteHelper in V8's api.cc.
+template<typename CharType>
+static inline int Write(const String* string, CharType* buffer, int start,
+                        int length, int options) {
+  MOZ_ASSERT(start >= 0 && length >= -1);
+
+  JSString* str = reinterpret_cast<const JS::Value*>(string)->toString();
+  int strLength = JS_GetStringLength(str);
+  Isolate* isolate = Isolate::GetCurrent();
+  JSContext* cx = JSContextFromIsolate(isolate);
+
+  int end = start + length;
+  if ((length == -1) || (length > strLength - start)) {
+    end = strLength;
+  }
+  if (end < 0) {
+    return 0;
+  }
+
+  if (!internal::CopyStringChars(cx, buffer, str, end - start, start)) {
+    return 0;
+  }
+
+  if (!(options & String::NO_NULL_TERMINATION) &&
+      (length == -1 || end - start < length)) {
+    buffer[end - start] = '\0';
+  }
+
+  return end - start;
+}
+
+// This is identical (modulo formatting) to the function of the same name
+// in jsstr.
+//
+// TODO: expose that function and get rid of this one.
+//
+uint32_t
+OneUcs4ToUtf8Char(uint8_t* utf8Buffer, uint32_t ucs4Char) {
+  MOZ_ASSERT(ucs4Char <= 0x10FFFF);
+
+  if (ucs4Char < 0x80) {
+    utf8Buffer[0] = uint8_t(ucs4Char);
+    return 1;
+  }
+
+  uint32_t a = ucs4Char >> 11;
+  uint32_t utf8Length = 2;
+  while (a) {
+    a >>= 5;
+    utf8Length++;
+  }
+
+  MOZ_ASSERT(utf8Length <= 4);
+
+  uint32_t i = utf8Length;
+  while (--i) {
+    utf8Buffer[i] = uint8_t((ucs4Char & 0x3F) | 0x80);
+    ucs4Char >>= 6;
+  }
+
+  utf8Buffer[0] = uint8_t(0x100 - (1 << (8 - utf8Length)) + ucs4Char);
+  return utf8Length;
+}
+
+const char16_t UTF8_REPLACEMENT_CHAR = u'\uFFFD';
+
+// There are two existing versions of this function: the public one
+// in CharacterEncoding and a private one in CTypes.
+//
+// Neither of them does quite what we want, since CharacterEncoding requires
+// the caller to ensure that the buffer is big enough to deflate the whole
+// string, while CTypes abort on a bad surrogate.  Whereas we want to abort
+// if the buffer runs out of space while continuing on a bad surrogate (which
+// we either replace with the replacement character or lossily convert).
+//
+// So this is a third implementation, based on those other two.  In theory,
+// it should be possible to refactor all three into a single implementation.
+//
+// TODO: that.
+//
+template <typename CharT>
+bool DeflateStringToUTF8Buffer(const CharT* src, size_t srclen,
+                               char* dst, size_t* dstlenp, int* numchrp,
+                               int options)
+{
+  size_t i, utf8Len;
+  char16_t c, c2;
+  uint32_t v;
+  uint8_t utf8buf[6];
+
+  size_t dstlen = *dstlenp;
+  size_t origDstlen = dstlen;
+  bool replaceInvalidUtf8 = (options & String::REPLACE_INVALID_UTF8);
+
+  while (srclen) {
+    c = *src++;
+    srclen--;
+    if (c >= 0xDC00 && c <= 0xDFFF) {
+      // bad surrogate pair (trailing surrogate at first byte of pair)
+      v = replaceInvalidUtf8 ? UTF8_REPLACEMENT_CHAR : c;
+    }
+    else if (c < 0xD800 || c > 0xDBFF) {
+      // non-surrogate
+      v = c;
+    } else {
+      // leading surrogate
+      if (srclen < 1) {
+        // bad surrogate pair (leading surrogate at end of string)
+        v = replaceInvalidUtf8 ? UTF8_REPLACEMENT_CHAR : c;
+      } else {
+        c2 = *src;
+        if ((c2 < 0xDC00) || (c2 > 0xDFFF)) {
+          // bad surrogate pair (second byte of pair not a trailing surrogate)
+          v = replaceInvalidUtf8 ? UTF8_REPLACEMENT_CHAR : c;
+        } else {
+          // valid surrogate pair
+          src++;
+          srclen--;
+          v = ((c - 0xD800) << 10) + (c2 - 0xDC00) + 0x10000;
+        }
+      }
+    }
+    if (v < 0x0080) {
+      /* no encoding necessary - performance hack */
+      if (dstlen == 0) {
+        goto bufferTooSmall;
+      }
+      *dst++ = (char) v;
+      utf8Len = 1;
+    } else {
+      utf8Len = OneUcs4ToUtf8Char(utf8buf, v);
+      if (utf8Len > dstlen) {
+        goto bufferTooSmall;
+      }
+      for (i = 0; i < utf8Len; i++) {
+        *dst++ = (char) utf8buf[i];
+      }
+    }
+    dstlen -= utf8Len;
+    if (numchrp != nullptr) {
+      (*numchrp)++;
+    }
+  }
+  *dstlenp = (origDstlen - dstlen);
+  return true;
+
+  bufferTooSmall:
+    *dstlenp = (origDstlen - dstlen);
+    return false;
+}
+
+template
+bool DeflateStringToUTF8Buffer(const JS::Latin1Char* src, size_t srclen,
+                               char* dst, size_t* dstlenp, int* numchrp,
+                               int options);
+
+template
+bool DeflateStringToUTF8Buffer(const char16_t* src, size_t srclen,
+                               char* dst, size_t* dstlenp, int* numchrp,
+                               int options);
+
+bool DeflateStringToUTF8Buffer(JSLinearString* str, char* dst, size_t* dstlenp,
+                               int* numchrp, int options)
+{
+  size_t length = js::GetLinearStringLength(str);
+
+  JS::AutoCheckCannotGC nogc;
+  return js::LinearStringHasLatin1Chars(str)
+         ? DeflateStringToUTF8Buffer(js::GetLatin1LinearStringChars(nogc, str),
+                                     length, dst, dstlenp, numchrp, options)
+         : DeflateStringToUTF8Buffer(js::GetTwoByteLinearStringChars(nogc, str),
+                                     length, dst, dstlenp, numchrp, options);
 }
 
 }

--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "v8.h"
+#include "jsfriendapi.h"
 
 struct JSContext;
 
@@ -44,6 +45,70 @@ struct ExternalOneByteStringFinalizer : ExternalStringFinalizerBase<ExternalOneB
   ExternalOneByteStringFinalizer(String::ExternalStringResourceBase* resource);
   static void FinalizeExternalString(const JSStringFinalizer* fin, char16_t* chars);
 };
+
+template<typename CharType>
+static inline int Write(const String* string, CharType* buffer, int start, int length, int options);
+
+// This is similar to the function of the same name in jsfriendapi, except that
+// it accepts an extra parameter, "start", that specifies the index in the "s"
+// string from which to begin copying.  And it's a template with specializations
+// so that CopyStringChars can call CopyLinearStringChars for both char16_t*
+// and char* "dest" arrays.
+//
+// TODO: upstream these enhancements into jsfriendapi.
+//
+template<typename CharType>
+MOZ_ALWAYS_INLINE void CopyLinearStringChars(CharType* dest, JSLinearString* s, size_t len, size_t start);
+
+MOZ_ALWAYS_INLINE void CopyLinearStringChars(char16_t* dest, JSLinearString* s, size_t len, size_t start) {
+  JS::AutoCheckCannotGC nogc;
+  if (js::LinearStringHasLatin1Chars(s)) {
+    const JS::Latin1Char* src = js::GetLatin1LinearStringChars(nogc, s);
+    for (size_t i = 0; i < len; i++) {
+      dest[i] = src[start + i];
+    }
+  } else {
+    const char16_t* src = js::GetTwoByteLinearStringChars(nogc, s);
+    mozilla::PodCopy(dest, src + start, len);
+  }
+}
+
+// There are two functions that do something similar, the public jsapi function
+// JS_EncodeStringToBuffer and the private jsstr function DeflateStringToBuffer.
+// But neither does quite what we want.  This version is mostly based on
+// the char16_t* specialization of CopyLinearStringChars, with some inspiration
+// from those other functions.
+MOZ_ALWAYS_INLINE void CopyLinearStringChars(char* dest, JSLinearString* s, size_t len, size_t start) {
+  JS::AutoCheckCannotGC nogc;
+  if (js::LinearStringHasLatin1Chars(s)) {
+    const JS::Latin1Char* src = js::GetLatin1LinearStringChars(nogc, s);
+    for (size_t i = 0; i < len; i++) {
+      dest[i] = char(src[start + i]);
+    }
+  } else {
+    const char16_t* src = js::GetTwoByteLinearStringChars(nogc, s);
+    for (size_t i = 0; i < len; i++) {
+      dest[i] = char(src[start + i]);
+    }
+  }
+}
+
+// Based on CopyStringChars in jsfriendapi, except for the "start" parameter
+// (as described above CopyLinearStringChars) and templatization (so it can take
+// both char16_t* and char* "dest" arrays).
+template<typename CharType>
+inline bool CopyStringChars(JSContext* cx, CharType* dest, JSString* s, size_t len, size_t start) {
+  JSLinearString* linear = js::StringToLinearString(cx, s);
+  if (!linear) {
+    return false;
+  }
+
+  CopyLinearStringChars(dest, linear, len, start);
+  return true;
+}
+
+bool DeflateStringToUTF8Buffer(JSLinearString* str, char* dst, size_t* dstlenp,
+                               int* numchrp, int options);
 
 }
 }

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -11,6 +11,32 @@
 
 #include "gtest/gtest.h"
 
+// From test-api.cc.
+static int StrCmp16(uint16_t* a, uint16_t* b) {
+  while (true) {
+    if (*a == 0 && *b == 0) return 0;
+    if (*a != *b) return 0 + *a - *b;
+    a++;
+    b++;
+  }
+}
+
+// From test-api.cc.
+static int StrNCmp16(uint16_t* a, uint16_t* b, int n) {
+  while (true) {
+    if (n-- == 0) return 0;
+    if (*a == 0 && *b == 0) return 0;
+    if (*a != *b) return 0 + *a - *b;
+    a++;
+    b++;
+  }
+}
+
+// Translations from cctest assertion macros to gtest equivalents, so we can
+// copy code from test-api.cc into this file with minimal modifications.
+#define CHECK_EQ(a, b) EXPECT_EQ(a, b)
+#define CHECK_NE(a, b) EXPECT_NE(a, b)
+
 void TestBoolean(Isolate* isolate, bool value) {
   Local<Boolean> boolean = Boolean::New(isolate, value);
   EXPECT_TRUE(boolean->IsBoolean());
@@ -920,6 +946,361 @@ TEST(SpiderShim, ExternalStringResourceDestructorCalled) {
   EXPECT_TRUE(externalStringResourceDestructorCalled);
   EXPECT_TRUE(externalOneByteStringResourceDestructorCalled);
 }
+
+// Begin code copied from THREADED_TEST(StringWrite) in test-api.cc.
+// Copyright 2012 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+TEST(SpiderShim, StringWrite) {
+  V8Engine engine;
+
+  Isolate::Scope isolate_scope(engine.isolate());
+
+  HandleScope handle_scope(engine.isolate());
+  Local<Context> context = Context::New(engine.isolate());
+  Context::Scope context_scope(context);
+
+  v8::Local<String> str = v8_str("abcde");
+  // abc<Icelandic eth><Unicode snowman>.
+  v8::Local<String> str2 = v8_str("abc\303\260\342\230\203");
+  v8::Local<String> str3 =
+      v8::String::NewFromUtf8(context->GetIsolate(), "abc\0def",
+                              v8::NewStringType::kNormal, 7)
+          .ToLocalChecked();
+  // "ab" + lead surrogate + "cd" + trail surrogate + "ef"
+  uint16_t orphans[8] = { 0x61, 0x62, 0xd800, 0x63, 0x64, 0xdc00, 0x65, 0x66 };
+  v8::Local<String> orphans_str =
+      v8::String::NewFromTwoByte(context->GetIsolate(), orphans,
+                                 v8::NewStringType::kNormal, 8)
+          .ToLocalChecked();
+  // single lead surrogate
+  uint16_t lead[1] = { 0xd800 };
+  v8::Local<String> lead_str =
+      v8::String::NewFromTwoByte(context->GetIsolate(), lead,
+                                 v8::NewStringType::kNormal, 1)
+          .ToLocalChecked();
+  // single trail surrogate
+  uint16_t trail[1] = { 0xdc00 };
+  v8::Local<String> trail_str =
+      v8::String::NewFromTwoByte(context->GetIsolate(), trail,
+                                 v8::NewStringType::kNormal, 1)
+          .ToLocalChecked();
+  // surrogate pair
+  uint16_t pair[2] = { 0xd800,  0xdc00 };
+  v8::Local<String> pair_str =
+      v8::String::NewFromTwoByte(context->GetIsolate(), pair,
+                                 v8::NewStringType::kNormal, 2)
+          .ToLocalChecked();
+  // const int kStride = 4;  // Must match stride in for loops in JS below.
+  // CompileRun(
+  //     "var left = '';"
+  //     "for (var i = 0; i < 0xd800; i += 4) {"
+  //     "  left = left + String.fromCharCode(i);"
+  //     "}");
+  // CompileRun(
+  //     "var right = '';"
+  //     "for (var i = 0; i < 0xd800; i += 4) {"
+  //     "  right = String.fromCharCode(i) + right;"
+  //     "}");
+  // v8::Local<v8::Object> global = context->Global();
+  // Local<String> left_tree = global->Get(context.local(), v8_str("left"))
+  //                               .ToLocalChecked()
+  //                               .As<String>();
+  // Local<String> right_tree = global->Get(context.local(), v8_str("right"))
+  //                                .ToLocalChecked()
+  //                                .As<String>();
+
+  // CHECK_EQ(5, str2->Length());
+  // CHECK_EQ(0xd800 / kStride, left_tree->Length());
+  // CHECK_EQ(0xd800 / kStride, right_tree->Length());
+
+  char buf[100];
+  char utf8buf[0xd800 * 3];
+  uint16_t wbuf[100];
+  int len;
+  int charlen;
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen);
+  CHECK_EQ(9, len);
+  CHECK_EQ(5, charlen);
+  CHECK_EQ(0, strcmp(utf8buf, "abc\303\260\342\230\203"));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 8, &charlen);
+  CHECK_EQ(8, len);
+  CHECK_EQ(5, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\303\260\342\230\203\1", 9));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 7, &charlen);
+  CHECK_EQ(5, len);
+  CHECK_EQ(4, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\303\260\1", 5));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 6, &charlen);
+  CHECK_EQ(5, len);
+  CHECK_EQ(4, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\303\260\1", 5));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 5, &charlen);
+  CHECK_EQ(5, len);
+  CHECK_EQ(4, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\303\260\1", 5));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 4, &charlen);
+  CHECK_EQ(3, len);
+  CHECK_EQ(3, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\1", 4));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 3, &charlen);
+  CHECK_EQ(3, len);
+  CHECK_EQ(3, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\1", 4));
+
+  memset(utf8buf, 0x1, 1000);
+  len = str2->WriteUtf8(utf8buf, 2, &charlen);
+  CHECK_EQ(2, len);
+  CHECK_EQ(2, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "ab\1", 3));
+
+  // allow orphan surrogates by default
+  memset(utf8buf, 0x1, 1000);
+  len = orphans_str->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen);
+  CHECK_EQ(13, len);
+  CHECK_EQ(8, charlen);
+  CHECK_EQ(0, strcmp(utf8buf, "ab\355\240\200cd\355\260\200ef"));
+
+  // replace orphan surrogates with unicode replacement character
+  memset(utf8buf, 0x1, 1000);
+  len = orphans_str->WriteUtf8(utf8buf,
+                               sizeof(utf8buf),
+                               &charlen,
+                               String::REPLACE_INVALID_UTF8);
+  CHECK_EQ(13, len);
+  CHECK_EQ(8, charlen);
+  CHECK_EQ(0, strcmp(utf8buf, "ab\357\277\275cd\357\277\275ef"));
+
+  // replace single lead surrogate with unicode replacement character
+  memset(utf8buf, 0x1, 1000);
+  len = lead_str->WriteUtf8(utf8buf,
+                            sizeof(utf8buf),
+                            &charlen,
+                            String::REPLACE_INVALID_UTF8);
+  CHECK_EQ(4, len);
+  CHECK_EQ(1, charlen);
+  CHECK_EQ(0, strcmp(utf8buf, "\357\277\275"));
+
+  // replace single trail surrogate with unicode replacement character
+  memset(utf8buf, 0x1, 1000);
+  len = trail_str->WriteUtf8(utf8buf,
+                             sizeof(utf8buf),
+                             &charlen,
+                             String::REPLACE_INVALID_UTF8);
+  CHECK_EQ(4, len);
+  CHECK_EQ(1, charlen);
+  CHECK_EQ(0, strcmp(utf8buf, "\357\277\275"));
+
+  // do not replace / write anything if surrogate pair does not fit the buffer
+  // space
+  memset(utf8buf, 0x1, 1000);
+  len = pair_str->WriteUtf8(utf8buf,
+                             3,
+                             &charlen,
+                             String::REPLACE_INVALID_UTF8);
+  CHECK_EQ(0, len);
+  CHECK_EQ(0, charlen);
+
+  // memset(utf8buf, 0x1, sizeof(utf8buf));
+  // len = GetUtf8Length(left_tree);
+  // int utf8_expected =
+  //     (0x80 + (0x800 - 0x80) * 2 + (0xd800 - 0x800) * 3) / kStride;
+  // CHECK_EQ(utf8_expected, len);
+  // len = left_tree->WriteUtf8(utf8buf, utf8_expected, &charlen);
+  // CHECK_EQ(utf8_expected, len);
+  // CHECK_EQ(0xd800 / kStride, charlen);
+  // CHECK_EQ(0xed, static_cast<unsigned char>(utf8buf[utf8_expected - 3]));
+  // CHECK_EQ(0x9f, static_cast<unsigned char>(utf8buf[utf8_expected - 2]));
+  // CHECK_EQ(0xc0 - kStride,
+  //          static_cast<unsigned char>(utf8buf[utf8_expected - 1]));
+  // CHECK_EQ(1, utf8buf[utf8_expected]);
+
+  // memset(utf8buf, 0x1, sizeof(utf8buf));
+  // len = GetUtf8Length(right_tree);
+  // CHECK_EQ(utf8_expected, len);
+  // len = right_tree->WriteUtf8(utf8buf, utf8_expected, &charlen);
+  // CHECK_EQ(utf8_expected, len);
+  // CHECK_EQ(0xd800 / kStride, charlen);
+  // CHECK_EQ(0xed, static_cast<unsigned char>(utf8buf[0]));
+  // CHECK_EQ(0x9f, static_cast<unsigned char>(utf8buf[1]));
+  // CHECK_EQ(0xc0 - kStride, static_cast<unsigned char>(utf8buf[2]));
+  // CHECK_EQ(1, utf8buf[utf8_expected]);
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf));
+  CHECK_EQ(5, len);
+  len = str->Write(wbuf);
+  CHECK_EQ(5, len);
+  CHECK_EQ(0, strcmp("abcde", buf));
+  uint16_t answer1[] = {'a', 'b', 'c', 'd', 'e', '\0'};
+  CHECK_EQ(0, StrCmp16(answer1, wbuf));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 0, 4);
+  CHECK_EQ(4, len);
+  len = str->Write(wbuf, 0, 4);
+  CHECK_EQ(4, len);
+  CHECK_EQ(0, strncmp("abcd\1", buf, 5));
+  uint16_t answer2[] = {'a', 'b', 'c', 'd', 0x101};
+  CHECK_EQ(0, StrNCmp16(answer2, wbuf, 5));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 0, 5);
+  CHECK_EQ(5, len);
+  len = str->Write(wbuf, 0, 5);
+  CHECK_EQ(5, len);
+  CHECK_EQ(0, strncmp("abcde\1", buf, 6));
+  uint16_t answer3[] = {'a', 'b', 'c', 'd', 'e', 0x101};
+  CHECK_EQ(0, StrNCmp16(answer3, wbuf, 6));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 0, 6);
+  CHECK_EQ(5, len);
+  len = str->Write(wbuf, 0, 6);
+  CHECK_EQ(5, len);
+  CHECK_EQ(0, strcmp("abcde", buf));
+  uint16_t answer4[] = {'a', 'b', 'c', 'd', 'e', '\0'};
+  CHECK_EQ(0, StrCmp16(answer4, wbuf));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 4, -1);
+  CHECK_EQ(1, len);
+  len = str->Write(wbuf, 4, -1);
+  CHECK_EQ(1, len);
+  CHECK_EQ(0, strcmp("e", buf));
+  uint16_t answer5[] = {'e', '\0'};
+  CHECK_EQ(0, StrCmp16(answer5, wbuf));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 4, 6);
+  CHECK_EQ(1, len);
+  len = str->Write(wbuf, 4, 6);
+  CHECK_EQ(1, len);
+  CHECK_EQ(0, strcmp("e", buf));
+  CHECK_EQ(0, StrCmp16(answer5, wbuf));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 4, 1);
+  CHECK_EQ(1, len);
+  len = str->Write(wbuf, 4, 1);
+  CHECK_EQ(1, len);
+  CHECK_EQ(0, strncmp("e\1", buf, 2));
+  uint16_t answer6[] = {'e', 0x101};
+  CHECK_EQ(0, StrNCmp16(answer6, wbuf, 2));
+
+  memset(buf, 0x1, sizeof(buf));
+  memset(wbuf, 0x1, sizeof(wbuf));
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf), 3, 1);
+  CHECK_EQ(1, len);
+  len = str->Write(wbuf, 3, 1);
+  CHECK_EQ(1, len);
+  CHECK_EQ(0, strncmp("d\1", buf, 2));
+  uint16_t answer7[] = {'d', 0x101};
+  CHECK_EQ(0, StrNCmp16(answer7, wbuf, 2));
+
+  memset(wbuf, 0x1, sizeof(wbuf));
+  wbuf[5] = 'X';
+  len = str->Write(wbuf, 0, 6, String::NO_NULL_TERMINATION);
+  CHECK_EQ(5, len);
+  CHECK_EQ('X', wbuf[5]);
+  uint16_t answer8a[] = {'a', 'b', 'c', 'd', 'e'};
+  uint16_t answer8b[] = {'a', 'b', 'c', 'd', 'e', '\0'};
+  CHECK_EQ(0, StrNCmp16(answer8a, wbuf, 5));
+  CHECK_NE(0, StrCmp16(answer8b, wbuf));
+  wbuf[5] = '\0';
+  CHECK_EQ(0, StrCmp16(answer8b, wbuf));
+
+  memset(buf, 0x1, sizeof(buf));
+  buf[5] = 'X';
+  len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf),
+                          0,
+                          6,
+                          String::NO_NULL_TERMINATION);
+  CHECK_EQ(5, len);
+  CHECK_EQ('X', buf[5]);
+  CHECK_EQ(0, strncmp("abcde", buf, 5));
+  CHECK_NE(0, strcmp("abcde", buf));
+  buf[5] = '\0';
+  CHECK_EQ(0, strcmp("abcde", buf));
+
+  memset(utf8buf, 0x1, sizeof(utf8buf));
+  utf8buf[8] = 'X';
+  len = str2->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen,
+                        String::NO_NULL_TERMINATION);
+  CHECK_EQ(8, len);
+  CHECK_EQ('X', utf8buf[8]);
+  CHECK_EQ(5, charlen);
+  CHECK_EQ(0, strncmp(utf8buf, "abc\303\260\342\230\203", 8));
+  CHECK_NE(0, strcmp(utf8buf, "abc\303\260\342\230\203"));
+  utf8buf[8] = '\0';
+  CHECK_EQ(0, strcmp(utf8buf, "abc\303\260\342\230\203"));
+
+  memset(utf8buf, 0x1, sizeof(utf8buf));
+  utf8buf[5] = 'X';
+  len = str->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen,
+                        String::NO_NULL_TERMINATION);
+  CHECK_EQ(5, len);
+  CHECK_EQ('X', utf8buf[5]);  // Test that the sixth character is untouched.
+  CHECK_EQ(5, charlen);
+  utf8buf[5] = '\0';
+  CHECK_EQ(0, strcmp(utf8buf, "abcde"));
+
+  memset(buf, 0x1, sizeof(buf));
+  len = str3->WriteOneByte(reinterpret_cast<uint8_t*>(buf));
+  CHECK_EQ(7, len);
+  CHECK_EQ(0, strcmp("abc", buf));
+  CHECK_EQ(0, buf[3]);
+  CHECK_EQ(0, strcmp("def", buf + 4));
+
+  CHECK_EQ(0, str->WriteOneByte(NULL, 0, 0, String::NO_NULL_TERMINATION));
+  CHECK_EQ(0, str->WriteUtf8(NULL, 0, 0, String::NO_NULL_TERMINATION));
+  CHECK_EQ(0, str->Write(NULL, 0, 0, String::NO_NULL_TERMINATION));
+}
+// End code copied from THREADED_TEST(StringWrite) in test-api.cc.
 
 TEST(SpiderShim, ToObject) {
   V8Engine engine;


### PR DESCRIPTION
This branch implements the String::Write, String::WriteOneByte, and String:WriteUtf8 methods, the last three unimplemented V8 String::\* methods that Node uses. It includes unit tests cribbed from V8's test suite, to confirm that its behavior conforms to V8's expectations.
