### PR TITLE
spidershim: Implement and stub out some of the v8::V8 methods

### DIFF
--- a/deps/spidershim/scripts/run-tests.sh
+++ b/deps/spidershim/scripts/run-tests.sh
@@ -9,7 +9,7 @@ if ! test -d "$BASE_DIR"; then
   exit 1
 fi
 
-for test in "$BASE_DIR"/out/{Debug,Release}/{hello-world,exception,persistent,trycatch,value}; do
+for test in "$BASE_DIR"/out/{Debug,Release}/{hello-world,exception,persistent,trycatch,value,v8}; do
   if ! "$test"; then
     >&2 echo "$test failed, see the log above"
     exit 1;

--- a/deps/spidershim/src/v8v8.cc
+++ b/deps/spidershim/src/v8v8.cc
@@ -55,21 +55,19 @@ bool V8::IsDead() {
 }
 
 const char *V8::GetVersion() {
-  // Spidermonkey's version number does not match the format of v8's (X.X.X.X),
-  // unsure if this will be an issue yet.
   return JS_GetImplementationVersion();
 }
 
 void V8::SetFlagsFromString(const char* str, int length) {
-  // TODO
+  // TODO: see SetFlagsFromCommandLine
 }
 
 void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
-  // TODO
+  // TODO: command line arguments should be added on an as-needed basis
 }
 
 void V8::SetEntropySource(EntropySource entropy_source) {
-  // TODO
+  // TODO: https://github.com/mozilla/spidernode/issues/58
 }
 
 }

--- a/deps/spidershim/src/v8v8.cc
+++ b/deps/spidershim/src/v8v8.cc
@@ -54,4 +54,22 @@ bool V8::IsDead() {
   return internal::gDisposed;
 }
 
+const char *V8::GetVersion() {
+  // Spidermonkey's version number does not match the format of v8's (X.X.X.X),
+  // unsure if this will be an issue yet.
+  return JS_GetImplementationVersion();
+}
+
+void V8::SetFlagsFromString(const char* str, int length) {
+  // TODO
+}
+
+void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
+  // TODO
+}
+
+void V8::SetEntropySource(EntropySource entropy_source) {
+  // TODO
+}
+
 }

--- a/deps/spidershim/test/v8.cc
+++ b/deps/spidershim/test/v8.cc
@@ -11,5 +11,5 @@
 #include "gtest/gtest.h"
 
 TEST(SpiderShim, Version) {
-  v8::V8::GetVersion();
+  EXPECT_EQ(strncmp("JavaScript-C", v8::V8::GetVersion(), 12), 0);
 }

--- a/deps/spidershim/test/v8v8.cc
+++ b/deps/spidershim/test/v8v8.cc
@@ -1,0 +1,15 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "v8engine.h"
+
+#include "gtest/gtest.h"
+
+TEST(SpiderShim, Version) {
+  v8::V8::GetVersion();
+}

--- a/deps/spidershim/tests.gyp
+++ b/deps/spidershim/tests.gyp
@@ -29,8 +29,8 @@
       'sources': [ 'test/value.cc' ],
     },
     {
-      'target_name': 'v8v8',
-      'sources': [ 'test/v8v8.cc' ],
+      'target_name': 'v8',
+      'sources': [ 'test/v8.cc' ],
     },
   ],
 }

--- a/deps/spidershim/tests.gyp
+++ b/deps/spidershim/tests.gyp
@@ -28,5 +28,9 @@
       'target_name': 'value',
       'sources': [ 'test/value.cc' ],
     },
+    {
+      'target_name': 'v8v8',
+      'sources': [ 'test/v8v8.cc' ],
+    },
   ],
 }


### PR DESCRIPTION
Fixes #31

I implemented the trivial version one, the rest of these seem low priority for getting up and running.
- GetVersion - may need some work to make the version number similar to a node version number
- SetFlagsFrom\* - I looked into fully implementing this by using jsshell's argument parser and option setter, but it's built into the main, so if we want to use that we'll need to do some work to extract it
- SetEntropySource - also stubbed out in chakra
