### PR TITLE
ensure string length <= max length

### DIFF
--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -77,17 +77,17 @@ Local<String> String::NewFromUtf8(Isolate* isolate, const char* data,
 
 MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, const char* data,
                                        v8::NewStringType type, int length) {
-  JSContext* cx = JSContextFromIsolate(isolate);
-
   // In V8's api.cc, this conditional block is annotated with the comment:
   //    TODO(dcarney): throw a context free exception.
-  if (length > v8::String::kMaxLength) {
+  if (length > String::kMaxLength) {
     return MaybeLocal<String>();
   }
 
   if (length < 0) {
     length = strlen(data);
   }
+
+  JSContext* cx = JSContextFromIsolate(isolate);
 
   size_t twoByteLen;
   JS::UniqueTwoByteChars twoByteChars(
@@ -112,6 +112,12 @@ MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, const char* data,
 
 MaybeLocal<String> String::NewFromOneByte(Isolate* isolate, const uint8_t* data,
                                           v8::NewStringType type, int length) {
+  // In V8's api.cc, this conditional block is annotated with the comment:
+  //    TODO(dcarney): throw a context free exception.
+  if (length > String::kMaxLength) {
+    return MaybeLocal<String>();
+  }
+
   JSContext* cx = JSContextFromIsolate(isolate);
 
   JSString* str =
@@ -140,6 +146,12 @@ Local<String> String::NewFromOneByte(Isolate* isolate, const uint8_t* data,
 
 MaybeLocal<String> String::NewFromTwoByte(Isolate* isolate, const uint16_t* data,
                                           v8::NewStringType type, int length) {
+  // In V8's api.cc, this conditional block is annotated with the comment:
+  //    TODO(dcarney): throw a context free exception.
+  if (length > String::kMaxLength) {
+    return MaybeLocal<String>();
+  }
+
   JSContext* cx = JSContextFromIsolate(isolate);
 
   JSString* str =
@@ -168,6 +180,12 @@ Local<String> String::NewFromTwoByte(Isolate* isolate, const uint16_t* data,
 
 MaybeLocal<String> String::NewExternalTwoByte(Isolate* isolate,
                                               ExternalStringResource* resource) {
+  // In V8's api.cc, this conditional block is annotated with the comment:
+  //    TODO(dcarney): throw a context free exception.
+  if (resource->length() > static_cast<size_t>(String::kMaxLength)) {
+    return MaybeLocal<String>();
+  }
+
   JSContext* cx = JSContextFromIsolate(isolate);
 
   auto fin = mozilla::MakeUnique<internal::ExternalStringFinalizer>(resource);
@@ -188,6 +206,12 @@ MaybeLocal<String> String::NewExternalTwoByte(Isolate* isolate,
 
 MaybeLocal<String> String::NewExternalOneByte(Isolate* isolate,
                                               ExternalOneByteStringResource* resource) {
+  // In V8's api.cc, this conditional block is annotated with the comment:
+  //    TODO(dcarney): throw a context free exception.
+  if (resource->length() > static_cast<size_t>(String::kMaxLength)) {
+    return MaybeLocal<String>();
+  }
+
   JSContext* cx = JSContextFromIsolate(isolate);
 
   auto fin = mozilla::MakeUnique<internal::ExternalOneByteStringFinalizer>(resource);
@@ -257,6 +281,10 @@ Local<String> String::Empty(Isolate* isolate) {
 }
 
 Local<String> String::Concat(Handle<String> left, Handle<String> right) {
+  if (left->Length() + right->Length() > String::kMaxLength) {
+    return Local<String>();
+  }
+
   Isolate* isolate = Isolate::GetCurrent();
   JSContext* cx = JSContextFromIsolate(isolate);
   JS::RootedString leftStr(cx, reinterpret_cast<JS::Value*>(*left)->toString());

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -1590,45 +1590,45 @@ TEST(SpiderShim, NewStringRangeError) {
   memset(buffer, 'A', buffer_size - 1);
   Isolate* isolate = engine.isolate();
   {
-    // TryCatch try_catch(isolate);
+    TryCatch try_catch(isolate);
     char* data = reinterpret_cast<char*>(buffer);
     CHECK(String::NewFromUtf8(isolate, data, NewStringType::kNormal,length)
             .IsEmpty());
-    // CHECK(!try_catch.HasCaught());
+    CHECK(!try_catch.HasCaught());
   }
   {
-    // TryCatch try_catch(isolate);
+    TryCatch try_catch(isolate);
     uint8_t* data = reinterpret_cast<uint8_t*>(buffer);
     CHECK(String::NewFromOneByte(isolate, data, NewStringType::kNormal, length)
             .IsEmpty());
-    // CHECK(!try_catch.HasCaught());
+    CHECK(!try_catch.HasCaught());
   }
   {
-    // TryCatch try_catch(isolate);
+    TryCatch try_catch(isolate);
     uint16_t* data = reinterpret_cast<uint16_t*>(buffer);
     CHECK(String::NewFromTwoByte(isolate, data, NewStringType::kNormal, length)
             .IsEmpty());
-    // CHECK(!try_catch.HasCaught());
+    CHECK(!try_catch.HasCaught());
   }
   {
-    // TryCatch try_catch(isolate);
+    TryCatch try_catch(isolate);
     uint16_t* data = reinterpret_cast<uint16_t*>(buffer);
     // Satisfy JSExternalString::new_ constraint that data is null-terminated.
     data[buffer_size/sizeof(uint16_t)] = '\0';
     TestExternalStringResource* testResource =
       new TestExternalStringResource(data, length);
     CHECK(String::NewExternalTwoByte(isolate, testResource).IsEmpty());
-    // CHECK(!try_catch.HasCaught());
+    CHECK(!try_catch.HasCaught());
   }
   {
-    // TryCatch try_catch(isolate);
+    TryCatch try_catch(isolate);
     char* data = reinterpret_cast<char*>(buffer);
     // Satisfy JSExternalString::new_ constraint that data is null-terminated.
     data[buffer_size/sizeof(char)] = '\0';
     TestExternalOneByteStringResource* testResource =
       new TestExternalOneByteStringResource(data, length);
     CHECK(String::NewExternalOneByte(isolate, testResource).IsEmpty());
-    // CHECK(!try_catch.HasCaught());
+    CHECK(!try_catch.HasCaught());
   }
   free(buffer);
 }
@@ -1647,10 +1647,10 @@ TEST(SpiderShim, StringConcatOverflow) {
   Local<String> str =
     String::NewExternalOneByte(engine.isolate(), r).ToLocalChecked();
   CHECK(!str.IsEmpty());
-  // TryCatch try_catch(engine.isolate());
+  TryCatch try_catch(engine.isolate());
   Local<String> result = String::Concat(str, str);
   CHECK(result.IsEmpty());
-  // CHECK(!try_catch.HasCaught());
+  CHECK(!try_catch.HasCaught());
 }
 
 TEST(SpiderShim, ToObject) {

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -65,6 +65,19 @@ static bool SameSymbol(Local<String> s1, Local<String> s2) {
 #define CHECK_EQ(a, b) EXPECT_EQ(a, b)
 #define CHECK_NE(a, b) EXPECT_NE(a, b)
 
+// From test-api.cc.
+class RandomLengthOneByteResource
+    : public String::ExternalOneByteStringResource {
+ public:
+  explicit RandomLengthOneByteResource(int length) : length_(length) {}
+  virtual const char* data() const { return string_; }
+  virtual size_t length() const { return length_; }
+
+ private:
+  char string_[10];
+  int length_;
+};
+
 void TestBoolean(Isolate* isolate, bool value) {
   Local<Boolean> boolean = Boolean::New(isolate, value);
   EXPECT_TRUE(boolean->IsBoolean());
@@ -1559,6 +1572,85 @@ TEST(SpiderShim, Utf16Symbol) {
   CHECK(SameSymbol(sym2, Local<String>::Cast(s2)));
   // CHECK(SameSymbol(sym3, Local<String>::Cast(s3)));
   CHECK(SameSymbol(sym4, Local<String>::Cast(s4)));
+}
+
+TEST(SpiderShim, NewStringRangeError) {
+  // This test is based on V8's NewStringRangeError test.
+
+  V8Engine engine;
+  Isolate::Scope isolate_scope(engine.isolate());
+  HandleScope handle_scope(engine.isolate());
+  Local<Context> context = Context::New(engine.isolate());
+  Context::Scope context_scope(context);
+
+  const int length = String::kMaxLength + 1;
+  const int buffer_size = length * sizeof(uint16_t);
+  void* buffer = malloc(buffer_size);
+  if (buffer == NULL) return;
+  memset(buffer, 'A', buffer_size - 1);
+  Isolate* isolate = engine.isolate();
+  {
+    // TryCatch try_catch(isolate);
+    char* data = reinterpret_cast<char*>(buffer);
+    CHECK(String::NewFromUtf8(isolate, data, NewStringType::kNormal,length)
+            .IsEmpty());
+    // CHECK(!try_catch.HasCaught());
+  }
+  {
+    // TryCatch try_catch(isolate);
+    uint8_t* data = reinterpret_cast<uint8_t*>(buffer);
+    CHECK(String::NewFromOneByte(isolate, data, NewStringType::kNormal, length)
+            .IsEmpty());
+    // CHECK(!try_catch.HasCaught());
+  }
+  {
+    // TryCatch try_catch(isolate);
+    uint16_t* data = reinterpret_cast<uint16_t*>(buffer);
+    CHECK(String::NewFromTwoByte(isolate, data, NewStringType::kNormal, length)
+            .IsEmpty());
+    // CHECK(!try_catch.HasCaught());
+  }
+  {
+    // TryCatch try_catch(isolate);
+    uint16_t* data = reinterpret_cast<uint16_t*>(buffer);
+    // Satisfy JSExternalString::new_ constraint that data is null-terminated.
+    data[buffer_size/sizeof(uint16_t)] = '\0';
+    TestExternalStringResource* testResource =
+      new TestExternalStringResource(data, length);
+    CHECK(String::NewExternalTwoByte(isolate, testResource).IsEmpty());
+    // CHECK(!try_catch.HasCaught());
+  }
+  {
+    // TryCatch try_catch(isolate);
+    char* data = reinterpret_cast<char*>(buffer);
+    // Satisfy JSExternalString::new_ constraint that data is null-terminated.
+    data[buffer_size/sizeof(char)] = '\0';
+    TestExternalOneByteStringResource* testResource =
+      new TestExternalOneByteStringResource(data, length);
+    CHECK(String::NewExternalOneByte(isolate, testResource).IsEmpty());
+    // CHECK(!try_catch.HasCaught());
+  }
+  free(buffer);
+}
+
+TEST(SpiderShim, StringConcatOverflow) {
+  // This test is based on V8's StringConcatOverflow test.
+
+  V8Engine engine;
+  Isolate::Scope isolate_scope(engine.isolate());
+  HandleScope handle_scope(engine.isolate());
+  Local<Context> context = Context::New(engine.isolate());
+  Context::Scope context_scope(context);
+
+  RandomLengthOneByteResource* r =
+    new RandomLengthOneByteResource(String::kMaxLength);
+  Local<String> str =
+    String::NewExternalOneByte(engine.isolate(), r).ToLocalChecked();
+  CHECK(!str.IsEmpty());
+  // TryCatch try_catch(engine.isolate());
+  Local<String> result = String::Concat(str, str);
+  CHECK(result.IsEmpty());
+  // CHECK(!try_catch.HasCaught());
 }
 
 TEST(SpiderShim, ToObject) {

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -32,6 +32,20 @@ static int StrNCmp16(uint16_t* a, uint16_t* b, int n) {
   }
 }
 
+// From allocation.h.
+template <typename T>
+T* NewArray(size_t size) {
+  T* result = new T[size];
+  // if (result == NULL) FatalProcessOutOfMemory("NewArray");
+  return result;
+}
+
+// From allocation.h.
+template <typename T>
+void DeleteArray(T* array) {
+  delete[] array;
+}
+
 /**
  * Ensure that the JSString object referenced by the first Local<String>
  * is the same JSString object referenced by the second Local<String>, i.e.
@@ -69,12 +83,18 @@ static bool SameSymbol(Local<String> s1, Local<String> s2) {
 class RandomLengthOneByteResource
     : public String::ExternalOneByteStringResource {
  public:
-  explicit RandomLengthOneByteResource(int length) : length_(length) {}
+  explicit RandomLengthOneByteResource(int length) : length_(length) {
+    string_ = NewArray<char>(length);
+    memset(string_, 0x1, length * sizeof(char));
+  }
+  ~RandomLengthOneByteResource() {
+    DeleteArray(string_);
+  }
   virtual const char* data() const { return string_; }
   virtual size_t length() const { return length_; }
 
  private:
-  char string_[10];
+  char* string_;
   int length_;
 };
 
@@ -1565,20 +1585,6 @@ TEST(SpiderShim, Utf16Symbol) {
   CHECK(SameSymbol(sym2, Local<String>::Cast(s2)));
   CHECK(SameSymbol(sym3, Local<String>::Cast(s3)));
   CHECK(SameSymbol(sym4, Local<String>::Cast(s4)));
-}
-
-// From allocation.h.
-template <typename T>
-T* NewArray(size_t size) {
-  T* result = new T[size];
-  // if (result == NULL) FatalProcessOutOfMemory("NewArray");
-  return result;
-}
-
-// From allocation.h.
-template <typename T>
-void DeleteArray(T* array) {
-  delete[] array;
 }
 
 // From vector.h.


### PR DESCRIPTION
Only String::NewFromUtf8 is currently checking that the new string data's length is <= String::kMaxLength. And String::Concat doesn't check that the concatenation is within the upper bound either. All the String::New\* methods and String::Concat should have this check. This branch adds it, plus tests.
