### PR TITLE
enable Travis for all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_script:
 script:
   - make V= -k || make V= -k || true
   - ./deps/spidershim/scripts/run-tests.sh
-branches:
-  only:
-    - master
 notifications:
   email: true
 env:


### PR DESCRIPTION
@ehsan Is it important to disable Travis on branches? There's only one other branch in the repository, container-based, and it appears to be defunct. Enabling Travis for branches makes it easier to test changes on Travis in my fork, since otherwise I have to enable it on each branch manually by modifying .travis.yml (and then undo those changes before requesting a pull).
