### PR TITLE
spidershim: Partially implement isolate terminate execution

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2362,6 +2362,7 @@ class V8_EXPORT Isolate {
     GCCallback callback, GCType gc_type_filter = kGCTypeAll);
   void RemoveGCEpilogueCallback(GCCallback callback);
 
+  bool IsExecutionTerminating();
   void CancelTerminateExecution();
   void TerminateExecution();
 

--- a/deps/spidershim/src/v8isolate.cc
+++ b/deps/spidershim/src/v8isolate.cc
@@ -102,6 +102,7 @@ Isolate::Isolate() : pimpl_(new Impl()) {
 
 Isolate::~Isolate() {
   assert(pimpl_->rt);
+  JS_SetInterruptCallback(pimpl_->rt, NULL);
   JS_DestroyRuntime(pimpl_->rt);
   delete pimpl_;
 }

--- a/deps/spidershim/src/v8isolate.h
+++ b/deps/spidershim/src/v8isolate.h
@@ -51,6 +51,8 @@ struct Isolate::Impl {
   mozilla::Maybe<internal::RootStore> eternals;
   std::vector<MessageCallback> messageListeners;
   void* embeddedData[internal::kNumIsolateDataSlots];
+  mozilla::Atomic<bool> serviceInterrupt;
+  mozilla::Atomic<bool> terminatingExecution;
 
   internal::RootStore& EnsurePersistents(Isolate* iso) {
     if (!persistents) {
@@ -72,6 +74,9 @@ struct Isolate::Impl {
             report->filename ? report->filename : "<no filename>",
             (unsigned int)report->lineno, message);
   }
+
+  static bool OnInterrupt(JSContext* cx);
+
 };
 
 JSContext* JSContextFromIsolate(v8::Isolate* isolate);

--- a/deps/spidershim/src/v8isolate.h
+++ b/deps/spidershim/src/v8isolate.h
@@ -37,7 +37,11 @@ bool InitializeIsolate();
 }
 
 struct Isolate::Impl {
-  Impl() : rt(nullptr), topTryCatch(nullptr) {
+  Impl()
+      : rt(nullptr),
+        topTryCatch(nullptr),
+        serviceInterrupt(false),
+        terminatingExecution(false) {
     memset(embeddedData, 0, sizeof(embeddedData));
   }
 
@@ -51,8 +55,8 @@ struct Isolate::Impl {
   mozilla::Maybe<internal::RootStore> eternals;
   std::vector<MessageCallback> messageListeners;
   void* embeddedData[internal::kNumIsolateDataSlots];
-  mozilla::Atomic<bool> serviceInterrupt;
-  mozilla::Atomic<bool> terminatingExecution;
+  bool serviceInterrupt;
+  bool terminatingExecution;
 
   internal::RootStore& EnsurePersistents(Isolate* iso) {
     if (!persistents) {

--- a/deps/spidershim/test/isolate.cc
+++ b/deps/spidershim/test/isolate.cc
@@ -10,6 +10,7 @@
 #include "v8engine.h"
 
 #include "gtest/gtest.h"
+#include "jsapi.h"
 
 bool message_received;
 
@@ -96,3 +97,101 @@ TEST(SpiderShim, IsolateEmbedderData) {
   }
 }
 
+bool Terminate(JSContext *cx, unsigned argc, JS::Value *vp) {
+  auto isolate = Isolate::GetCurrent();
+  EXPECT_TRUE(!isolate->IsExecutionTerminating());
+  isolate->TerminateExecution();
+
+  JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+  args.rval().setUndefined();
+  return true;
+}
+
+bool Fail(JSContext *cx, unsigned argc, JS::Value *vp) {
+  EXPECT_TRUE(false);
+  return true;
+}
+
+Local<Value> CompileRun(const char* script) {
+  auto scr = Script::Compile(v8_str(script));
+  if (*scr) {
+    return scr->Run();
+  }
+  return Local<Value>();
+}
+
+bool Loop(JSContext *cx, unsigned argc, JS::Value *vp) {
+  auto isolate = Isolate::GetCurrent();
+  EXPECT_FALSE(isolate->IsExecutionTerminating());
+
+  MaybeLocal<Value> result =
+      CompileRun("try { doloop(); fail(); } catch(e) { fail(); }");
+  EXPECT_TRUE(result.IsEmpty());
+  EXPECT_TRUE(isolate->IsExecutionTerminating());
+
+  JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+  args.rval().setUndefined();
+  return false;
+}
+
+bool DoLoop(JSContext *cx, unsigned argc, JS::Value *vp) {
+  auto isolate = Isolate::GetCurrent();
+  TryCatch try_catch(isolate);
+  EXPECT_FALSE(isolate->IsExecutionTerminating());
+  MaybeLocal<Value> result =
+      CompileRun("function f() {"
+                 "  var term = true;"
+                 "  try {"
+                 "    while(true) {"
+                 "      if (term) terminate();"
+                 "      term = false;"
+                 "    }"
+                 "    fail();"
+                 "  } catch(e) {"
+                 "    fail();"
+                 "  }"
+                 "}"
+                 "f()");
+  EXPECT_TRUE(result.IsEmpty());
+  JS_IsExceptionPending(cx);
+  // TODO: enable these https://github.com/mozilla/spidernode/issues/96
+  // EXPECT_TRUE(try_catch.HasCaught());
+  // EXPECT_TRUE(try_catch.Exception()->IsNull());
+  // EXPECT_TRUE(try_catch.Message().IsEmpty());
+  // EXPECT_FALSE(try_catch.CanContinue());
+  EXPECT_TRUE(isolate->IsExecutionTerminating());
+
+  JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+  args.rval().setUndefined();
+  return false;
+}
+
+void CreateGlobalTemplate(
+    JSContext *smContext, JS::Handle<JSObject *> smGlobal, JSNative doloop) {
+
+  EXPECT_TRUE(JS_DefineFunction(smContext, smGlobal, "terminate", &Terminate, 0, 0));
+  EXPECT_TRUE(JS_DefineFunction(smContext, smGlobal, "fail", &Fail, 0, 0));
+  EXPECT_TRUE(JS_DefineFunction(smContext, smGlobal, "loop", &Loop, 0, 0));
+  EXPECT_TRUE(JS_DefineFunction(smContext, smGlobal, "doloop", doloop, 0, 0));
+}
+
+TEST(SpiderShim, TerminateExecution) {
+  // This test is based on V8's TerminateOnlyV8ThreadFromThreadItself.
+  // TODO: update this test when object/function templates work
+  // https://github.com/mozilla/spidernode/issues/95
+  V8Engine engine;
+  Isolate::Scope isolate_scope(engine.isolate());
+
+  HandleScope handle_scope(engine.isolate());
+  Local<Context> context = Context::New(engine.isolate());
+  Context::Scope context_scope(context);
+
+  Local<Object> globalObj = context->Global();
+  auto smContext = JSContextFromContext(*context);
+  JS::RootedObject smGlobal(smContext, &reinterpret_cast<JS::Value*>(*globalObj)->toObject());
+
+  CreateGlobalTemplate(smContext, smGlobal, DoLoop);
+
+  MaybeLocal<Value> result = engine.CompileRun(context, "loop();");
+  EXPECT_TRUE(result.IsEmpty());
+}


### PR DESCRIPTION
This will need more work when object/function template is implemented.

I filed bugs #95 and #96 and wrote more in https://github.com/mozilla/spidernode/issues/85#issuecomment-219587766
