### PR TITLE
spidershim: fix free call for clang 7.3

### DIFF
--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -1642,7 +1642,7 @@ class TestOneByteResource : public String::ExternalOneByteStringResource {
         counter_(counter) {}
 
   ~TestOneByteResource() {
-    free(orig_data_);
+    free(const_cast<char*>(orig_data_));
     if (counter_ != NULL) ++*counter_;
   }
 


### PR DESCRIPTION
../deps/spidershim/test/value.cc:1645:5: error: no matching function for call to 'free'
    free(orig_data_);
    ^~~~
/usr/include/stdlib.h:143:7: note: candidate function not viable: no known conversion from 'const char *' to 'void *' for 1st argument; take the address of the argument with &
void     free(void *);
