### PR TITLE
spidershim: implement parts of Isolate::GetHeapStatistics

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2480,19 +2480,21 @@ class V8_EXPORT Exception {
 
 class V8_EXPORT HeapStatistics {
  private:
-  size_t heapSize;
+  size_t total_heap_size_;
+  size_t used_heap_size_;
+
 
  public:
-  void set_heap_size(size_t heapSize) {
-    this->heapSize = heapSize;
-  }
+  HeapStatistics() : total_heap_size_(0), used_heap_size_(0) {};
 
-  size_t total_heap_size() { return this->heapSize; }
+  size_t total_heap_size() { return this->total_heap_size_; }
   size_t total_heap_size_executable() { return 0; }
   size_t total_physical_size() { return 0; }
   size_t total_available_size() { return 0; }
-  size_t used_heap_size() { return this->heapSize; }
+  size_t used_heap_size() { return this->used_heap_size_; }
   size_t heap_size_limit() { return 0; }
+
+  friend class Isolate;
 };
 
 class V8_EXPORT HeapSpaceStatistics {

--- a/deps/spidershim/src/v8isolate.cc
+++ b/deps/spidershim/src/v8isolate.cc
@@ -25,8 +25,10 @@
 #include "v8.h"
 #include "v8isolate.h"
 #include "jsapi.h"
+#include "js/MemoryMetrics.h"
 #include "mozilla/TimeStamp.h"
 #include "mozilla/ThreadLocal.h"
+#include "mozilla/mozalloc.h"
 
 namespace v8 {
 
@@ -337,6 +339,30 @@ size_t NumberOfHeapSpaces() {
   // Spidermonkey doesn't expose this and it's only used by node to allocate
   // the heap's name to avoid creating it multiple times.
   return 0;
+}
+
+class SimpleJSRuntimeStats : public JS::RuntimeStats {
+  public:
+    explicit SimpleJSRuntimeStats(mozilla::MallocSizeOf mallocSizeOf)
+      : JS::RuntimeStats(mallocSizeOf)
+    {}
+
+    virtual void initExtraZoneStats(JS::Zone* zone, JS::ZoneStats* zStats)
+        override
+    {}
+
+    virtual void initExtraCompartmentStats(
+        JSCompartment* c, JS::CompartmentStats* cStats) override
+    {}
+};
+
+void Isolate::GetHeapStatistics(HeapStatistics *heap_statistics) {
+  SimpleJSRuntimeStats rtStats(moz_malloc_size_of);
+  if (!JS::CollectRuntimeStats(Runtime(), &rtStats, nullptr, false)) {
+    return;
+  }
+  heap_statistics->total_heap_size_ = rtStats.gcHeapChunkTotal;
+  heap_statistics->used_heap_size_ = rtStats.gcHeapGCThings;
 }
 
 }

--- a/deps/spidershim/test/isolate.cc
+++ b/deps/spidershim/test/isolate.cc
@@ -309,7 +309,7 @@ TEST(SpiderShim, Microtask) {
   HandleScope handle_scope(engine.isolate());
   Local<Context> context = Context::New(engine.isolate());
   Context::Scope context_scope(context);
-
+  
   Local<Object> globalObj = context->Global();
   auto smContext = JSContextFromContext(*context);
   JS::RootedObject smGlobal(smContext, &reinterpret_cast<JS::Value*>(*globalObj)->toObject());
@@ -324,4 +324,21 @@ TEST(SpiderShim, Microtask) {
   on_fulfilled_called = false;
   engine.isolate()->RunMicrotasks();
   EXPECT_FALSE(on_fulfilled_called);
+}
+
+TEST(SpiderShim, GetHeapStatistics) {
+  // This test is based on V8's GetHeapStatistics.
+  V8Engine engine;
+  Isolate::Scope isolate_scope(engine.isolate());
+
+  HandleScope handle_scope(engine.isolate());
+  Local<Context> context = Context::New(engine.isolate());
+  Context::Scope context_scope(context);
+
+  HeapStatistics heap_statistics;
+  EXPECT_EQ(0u, heap_statistics.total_heap_size());
+  EXPECT_EQ(0u, heap_statistics.used_heap_size());
+  engine.isolate()->GetHeapStatistics(&heap_statistics);
+  EXPECT_NE(static_cast<int>(heap_statistics.total_heap_size()), 0);
+  EXPECT_NE(static_cast<int>(heap_statistics.used_heap_size()), 0);
 }


### PR DESCRIPTION
It may be possible to fill in a few more of these, but I'll need to get some more feedback from people who know spidermonkey's memory data better.

Fixes #114
