### PR TITLE
use upstreamed DeflateStringToUTF8Buffer

### DIFF
--- a/deps/spidershim/src/v8string.h
+++ b/deps/spidershim/src/v8string.h
@@ -117,7 +117,5 @@ inline bool CopyStringChars(JSContext* cx, CharType* dest, JSString* s,
   return true;
 }
 
-bool DeflateStringToUTF8Buffer(JSLinearString* str, char* dst, size_t* dstlenp,
-                               int* numchrp, int options);
 }
 }

--- a/deps/spidershim/test/value.cc
+++ b/deps/spidershim/test/value.cc
@@ -1254,11 +1254,13 @@ TEST(SpiderShim, StringWrite) {
   CHECK_EQ(0, strncmp(utf8buf, "ab\1", 3));
 
   // allow orphan surrogates by default
-  memset(utf8buf, 0x1, 1000);
-  len = orphans_str->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen);
-  CHECK_EQ(13, len);
-  CHECK_EQ(8, charlen);
-  CHECK_EQ(0, strcmp(utf8buf, "ab\355\240\200cd\355\260\200ef"));
+  // TODO: re-enable once upstream JS::DeflateStringToUTF8Buffer supports
+  // writing orphan surrogates to the output buffer.
+  // memset(utf8buf, 0x1, 1000);
+  // len = orphans_str->WriteUtf8(utf8buf, sizeof(utf8buf), &charlen);
+  // CHECK_EQ(13, len);
+  // CHECK_EQ(8, charlen);
+  // CHECK_EQ(0, strcmp(utf8buf, "ab\355\240\200cd\355\260\200ef"));
 
   // replace orphan surrogates with unicode replacement character
   memset(utf8buf, 0x1, 1000);


### PR DESCRIPTION
The only part of the downstream implementation that I didn't upstream was support for writing orphaned surrogates to the output buffer, which Node doesn't use. I've commented out the test for that and filed #122 to implement it in the future.
