### PR TITLE
spidershim: implement v8::Isolate:ThrowException

### DIFF
--- a/deps/spidershim/src/v8isolate.cc
+++ b/deps/spidershim/src/v8isolate.cc
@@ -219,6 +219,13 @@ void Isolate::CancelTerminateExecution() {
   pimpl_->terminatingExecution = false;
 }
 
+Local<Value> Isolate::ThrowException(Local<Value> exception) {
+  auto context = JSContextFromIsolate(this);
+  JS::RootedValue rval(context, *GetValue(exception));
+  JS_SetPendingException(context, rval);
+  return Undefined(this);
+}
+
 void Isolate::AddStackFrame(StackFrame* frame) {
   assert(pimpl_);
   pimpl_->stackFrames.push_back(frame);


### PR DESCRIPTION
I have some tests for this locally (that pass) but they require exposing the private `static Local<T> New(Isolate* isolate, S* that);`, though this won't be needed when we have function/object templates. If wanted I could temporarily make them public, but I think we should just file a follow up issue to enables tests once function/object templates have landed.
