### PR TITLE
make SpiderMonkey the default JS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ Building on any OS other than Linux or OS X has not been tested.
 
 Build Command:
 ```bash
-./configure --engine=spidermonkey [options]
+./configure [options]
 make
 ```
 
-Where `options` is one or more of:
+Where `options` is zero or more of:
+* `--engine`: The JavaScript engine to use.  The default engine is `spidermonkey`.
 * `--debug`: Also build in debug mode.  The default build configuration is release.
 * `--enable-gczeal`: Enable SpiderMonkey gc-zeal support.  This is useful for debugging GC rooting correctness issues.
 

--- a/configure
+++ b/configure
@@ -423,8 +423,8 @@ parser.add_option('--enable-gczeal',
 parser.add_option('--engine',
     action='store',
     dest='engine',
-    default='v8',
-    help='Use specified JS engine (default is V8)')
+    default='spidermonkey',
+    help='Use specified JS engine (default is SpiderMonkey)')
 
 
 (options, args) = parser.parse_args()


### PR DESCRIPTION
This simplifies building slightly, both when building manually and when configuring another project to build this one (i.e. configuring Electron to build this fork of Node). Of course we'd need to undo this change before merging to upstream Node, but that's in the hazy future.

I did something similar to Positron over in https://github.com/mozilla/positron/pull/81, where configuring your clone to build Positron required the cumbersome step of hacking a .mozconfig file. It's less of an issue for SpiderNode, since the configuration happens on the command line. But it's still a bit easier if you don't have to configure the engine explicitly. After all, no one will clone a repository named "spidernode" expecting to build Node with V8.
