### PR TITLE
spidershim: Add some more ObjectTemplate tests.

### DIFF
--- a/deps/spidershim/test/object.cc
+++ b/deps/spidershim/test/object.cc
@@ -30,10 +30,10 @@ TEST(SpiderShim, ReplaceConstantFunction) {
       .FromJust();
   Local<Object> obj_clone = obj->Clone();
   obj_clone->Set(context, foo_string, v8_str("Hello")).FromJust();
-  ASSERT_TRUE(!obj->Get(context, foo_string).ToLocalChecked()->IsUndefined());
-  ASSERT_TRUE(!obj->Get(context, foo_string).ToLocalChecked()->IsString());
-  ASSERT_TRUE(obj->Get(context, foo_string).ToLocalChecked()->IsFunction());
-  ASSERT_TRUE(obj_clone->Get(context, foo_string).ToLocalChecked()->IsString());
-  ASSERT_TRUE(!obj_clone->Get(context, foo_string).ToLocalChecked()->IsFunction());
+  EXPECT_TRUE(!obj->Get(context, foo_string).ToLocalChecked()->IsUndefined());
+  EXPECT_TRUE(!obj->Get(context, foo_string).ToLocalChecked()->IsString());
+  EXPECT_TRUE(obj->Get(context, foo_string).ToLocalChecked()->IsFunction());
+  EXPECT_TRUE(obj_clone->Get(context, foo_string).ToLocalChecked()->IsString());
+  EXPECT_TRUE(!obj_clone->Get(context, foo_string).ToLocalChecked()->IsFunction());
 }
 

--- a/deps/spidershim/test/template.cc
+++ b/deps/spidershim/test/template.cc
@@ -30,7 +30,7 @@ static void Returns42(const FunctionCallbackInfo<Value>& info) {
 }
 
 static void Gets42(Local<String> property,
-		   const PropertyCallbackInfo<Value>& info) {
+                   const PropertyCallbackInfo<Value>& info) {
   info.GetReturnValue().Set(42);
 }
 
@@ -214,8 +214,8 @@ static void TestObjectTemplateInheritedWithPrototype(
             fun_B->GetFunction(context).ToLocalChecked();
         if (i == 0) {
           EXPECT_TRUE(context->Global()
-		        ->Set(context, class_name, function_B)
-		        .FromJust());
+                        ->Set(context, class_name, function_B)
+                        .FromJust());
         }
         instance =
             CompileRun("new B()")->ToObject(context).ToLocalChecked();
@@ -370,7 +370,7 @@ TEST(SpiderShim, FunctionTemplateSetLength) {
   {
     Local<FunctionTemplate> fun_templ =
         FunctionTemplate::New(isolate, handle_callback_1, Local<Value>(),
-			      Local<Signature>(), 23);
+                              Local<Signature>(), 23);
     Local<Function> fun = fun_templ->GetFunction(context).ToLocalChecked();
     EXPECT_TRUE(context->Global()->Set(context, v8_str("obj"), fun).FromJust());
     Local<Script> script = v8_compile("obj.length");
@@ -399,30 +399,30 @@ static void IncrementingSignatureCallback(
   EXPECT_TRUE(signature_expected_receiver->Equals(
                                        args.GetIsolate()->GetCurrentContext(),
                                        args.Holder())
-	        .FromJust());
+                .FromJust());
   EXPECT_TRUE(signature_expected_receiver->Equals(
                                        args.GetIsolate()->GetCurrentContext(),
                                        args.This())
-	        .FromJust());
+                .FromJust());
   v8::Local<v8::Array> result =
       v8::Array::New(args.GetIsolate(), args.Length());
   for (int i = 0; i < args.Length(); i++) {
     EXPECT_TRUE(result->Set(args.GetIsolate()->GetCurrentContext(),
                       v8::Integer::New(args.GetIsolate(), i), args[i])
-		  .FromJust());
+                  .FromJust());
   }
   args.GetReturnValue().Set(result);
 }
 
 static void TestSignature(V8Engine& engine, Local<Context> context,
-			  const char* loop_js,
-			  Local<Value> receiver, Isolate* isolate) {
+                          const char* loop_js,
+                          Local<Value> receiver, Isolate* isolate) {
   char source[200];
   sprintf(source,
-	  "for (var i = 0; i < 10; i++) {"
-	  "  %s"
-	  "}",
-	  loop_js);
+          "for (var i = 0; i < 10; i++) {"
+          "  %s"
+          "}",
+          loop_js);
   signature_callback_count = 0;
   signature_expected_receiver = receiver;
   bool expected_to_throw = receiver.IsEmpty();
@@ -753,35 +753,6 @@ TEST(SpiderShim, InstanceCheckOnPrototypeAccessor) {
   CheckInstanceCheckedAccessors(true);
 }
 
-static void GetXValue(Local<Name> name,
-                      const PropertyCallbackInfo<Value>& info) {
-  ASSERT_TRUE(info.Data()->Equals(v8_str("donut")));
-  ASSERT_TRUE(name->Equals(v8_str("x")));
-  info.GetReturnValue().Set(name);
-}
-
-TEST(SpiderShim, SimplePropertyRead) {
-  // based on the V8 test-api.cc SimplePropertyRead test.
-  V8Engine engine;
-  Isolate* isolate = engine.isolate();
-  Isolate::Scope isolate_scope(isolate);
-  HandleScope scope(isolate);
-  Local<Context> context = Context::New(isolate);
-  Context::Scope context_scope(context);
-
-  Local<ObjectTemplate> templ = ObjectTemplate::New(isolate);
-  templ->SetAccessor(v8_str("x"), GetXValue, NULL, v8_str("donut"));
-  ASSERT_TRUE(context->Global()
-            ->Set(context, v8_str("obj"),
-                  templ->NewInstance(context).ToLocalChecked())
-            .FromJust());
-  Local<Script> script = v8_compile("obj.x");
-  for (int i = 0; i < 10; i++) {
-    Local<Value> result = script->Run(context).ToLocalChecked();
-    ASSERT_TRUE(result->Equals(context, v8_str("x")).FromJust());
-  }
-}
-
 static void SimpleCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   info.GetReturnValue().Set(v8_num(51423 + info.Length()));
 }
@@ -801,18 +772,18 @@ TEST(SpiderShim, SimpleCallback) {
                        FunctionTemplate::New(isolate, SimpleCallback));
   Local<Object> object =
       object_template->NewInstance(context).ToLocalChecked();
-  ASSERT_TRUE(context
-	      ->Global()
-	      ->Set(context, v8_str("callback_object"), object)
-	      .FromJust());
+  EXPECT_TRUE(context
+              ->Global()
+              ->Set(context, v8_str("callback_object"), object)
+              .FromJust());
   Local<Script> script;
   script = v8_compile("callback_object.callback(17)");
   for (int i = 0; i < 30; i++) {
-    ASSERT_EQ(51424, v8_run_int32value(script));
+    EXPECT_EQ(51424, v8_run_int32value(script));
   }
   script = v8_compile("callback_object.callback(17, 24)");
   for (int i = 0; i < 30; i++) {
-    ASSERT_EQ(51425, v8_run_int32value(script));
+    EXPECT_EQ(51425, v8_run_int32value(script));
   }
 }
 
@@ -936,12 +907,12 @@ TEST(SpiderShim, FunctionPrototype) {
 
   Local<FunctionTemplate> Foo = FunctionTemplate::New(isolate);
   Foo->PrototypeTemplate()->Set(v8_str("plak"), v8_num(321));
-  ASSERT_TRUE(context->Global()
+  EXPECT_TRUE(context->Global()
             ->Set(context, v8_str("Foo"),
                   Foo->GetFunction(context).ToLocalChecked())
             .FromJust());
   Local<Script> script = v8_compile("Foo.prototype.plak");
-  ASSERT_EQ(v8_run_int32value(script), 321);
+  EXPECT_EQ(v8_run_int32value(script), 321);
 }
 
 static void InstanceFunctionCallback(
@@ -972,12 +943,12 @@ TEST(SpiderShim, InstanceProperties) {
                        ->NewInstance(context)
                        .ToLocalChecked();
 
-  ASSERT_TRUE(context->Global()->Set(context, v8_str("i"), o).FromJust());
+  EXPECT_TRUE(context->Global()->Set(context, v8_str("i"), o).FromJust());
   Local<Value> value = CompileRun("i.x");
-  ASSERT_EQ(42, value->Int32Value(context).FromJust());
+  EXPECT_EQ(42, value->Int32Value(context).FromJust());
 
   value = CompileRun("i.f()");
-  ASSERT_EQ(12, value->Int32Value(context).FromJust());
+  EXPECT_EQ(12, value->Int32Value(context).FromJust());
 }
 
 TEST(SpiderShim, Constructor) {
@@ -993,11 +964,11 @@ TEST(SpiderShim, Constructor) {
   Local<FunctionTemplate> templ = FunctionTemplate::New(isolate);
   templ->SetClassName(v8_str("Fun"));
   Local<Function> cons = templ->GetFunction(context).ToLocalChecked();
-  ASSERT_TRUE(
+  EXPECT_TRUE(
       context->Global()->Set(context, v8_str("Fun"), cons).FromJust());
   Local<Object> inst = cons->NewInstance(context).ToLocalChecked();
   Local<Value> value = CompileRun("(new Fun()).constructor === Fun");
-  ASSERT_TRUE(value->BooleanValue(context).FromJust());
+  EXPECT_TRUE(value->BooleanValue(context).FromJust());
 }
 
 static void IsConstructHandler(
@@ -1019,16 +990,16 @@ TEST(SpiderShim, IsConstructCall) {
   Local<v8::FunctionTemplate> templ = v8::FunctionTemplate::New(isolate);
   templ->SetCallHandler(IsConstructHandler);
 
-  ASSERT_TRUE(context->Global()
+  EXPECT_TRUE(context->Global()
             ->Set(context, v8_str("f"),
                   templ->GetFunction(context).ToLocalChecked())
             .FromJust());
   Local<Value> value = v8_compile("f()")->Run(context).ToLocalChecked();
-  ASSERT_TRUE(!value->BooleanValue(context).FromJust());
+  EXPECT_TRUE(!value->BooleanValue(context).FromJust());
   // TODO: new f() hits a SpiderMonkey assert.  See
   // https://github.com/mozilla/spidernode/issues/157
   // value = v8_compile("new f()")->Run(context).ToLocalChecked();
-  // ASSERT_TRUE(value->BooleanValue(context).FromJust());
+  // EXPECT_TRUE(value->BooleanValue(context).FromJust());
 }
 
 static void FunctionNameCallback(
@@ -1050,12 +1021,370 @@ TEST(SpiderShim, CallbackFunctionName) {
   Local<ObjectTemplate> t = ObjectTemplate::New(isolate);
   t->Set(v8_str("asdf"),
          FunctionTemplate::New(isolate, FunctionNameCallback));
-  ASSERT_TRUE(context->Global()
+  EXPECT_TRUE(context->Global()
             ->Set(context, v8_str("obj"),
                   t->NewInstance(context).ToLocalChecked())
             .FromJust());
   Local<Value> value = CompileRun("obj.asdf.name");
-  ASSERT_TRUE(value->IsString());
+  EXPECT_TRUE(value->IsString());
   String::Utf8Value name(value);
-  ASSERT_EQ(0, strcmp("asdf", *name));
+  EXPECT_EQ(0, strcmp("asdf", *name));
+}
+
+static void ArgumentsTestCallback(
+    const FunctionCallbackInfo<Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  EXPECT_EQ(3, args.Length());
+  EXPECT_TRUE(v8::Integer::New(isolate, 1)->Equals(context, args[0]).FromJust());
+  EXPECT_TRUE(v8::Integer::New(isolate, 2)->Equals(context, args[1]).FromJust());
+  EXPECT_TRUE(v8::Integer::New(isolate, 3)->Equals(context, args[2]).FromJust());
+  EXPECT_TRUE(v8::Undefined(isolate)->Equals(context, args[3]).FromJust());
+}
+
+TEST(SpiderShim, Arguments) {
+  // Based on the V8 test-api.cc Arguments test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  context->Global()->Set(v8_str("f"),
+			 FunctionTemplate::New(isolate, ArgumentsTestCallback)->GetFunction());
+  v8_compile("f(1, 2, 3)")->Run(context).ToLocalChecked();
+}
+
+static int p_getter_count;
+static int p_getter_count2;
+
+static void PGetter(Local<Name> name,
+                    const PropertyCallbackInfo<Value>& info) {
+  p_getter_count++;
+  Local<Context> context = info.GetIsolate()->GetCurrentContext();
+  Local<Object> global = context->Global();
+  ASSERT_TRUE(
+      info.Holder()
+          ->Equals(context, global->Get(context, v8_str("o1")).ToLocalChecked())
+          .FromJust());
+  if (name->Equals(context, v8_str("p1")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o1")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p2")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o2")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p3")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o3")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p4")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o4")).ToLocalChecked())
+              .FromJust());
+  }
+}
+
+static void RunHolderTest(Local<Context> context, Local<ObjectTemplate> obj) {
+  ASSERT_TRUE(context->Global()
+            ->Set(context, v8_str("o1"),
+                  obj->NewInstance(context).ToLocalChecked())
+            .FromJust());
+  CompileRun(
+    "o1.__proto__ = { };"
+    "var o2 = { __proto__: o1 };"
+    "var o3 = { __proto__: o2 };"
+    "var o4 = { __proto__: o3 };"
+    "for (var i = 0; i < 10; i++) o4.p4;"
+    "for (var i = 0; i < 10; i++) o3.p3;"
+    "for (var i = 0; i < 10; i++) o2.p2;"
+    "for (var i = 0; i < 10; i++) o1.p1;");
+}
+
+
+static void PGetter2(Local<Name> name,
+                     const PropertyCallbackInfo<Value>& info) {
+  p_getter_count2++;
+  Local<Context> context = info.GetIsolate()->GetCurrentContext();
+  Local<Object> global = context->Global();
+  ASSERT_TRUE(
+      info.Holder()
+          ->Equals(context, global->Get(context, v8_str("o1")).ToLocalChecked())
+          .FromJust());
+  if (name->Equals(context, v8_str("p1")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o1")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p2")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o2")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p3")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o3")).ToLocalChecked())
+              .FromJust());
+  } else if (name->Equals(context, v8_str("p4")).FromJust()) {
+    ASSERT_TRUE(info.This()
+              ->Equals(context,
+                       global->Get(context, v8_str("o4")).ToLocalChecked())
+              .FromJust());
+  }
+}
+
+
+#if 0
+// Skip the GetterHolders test for now, because we don't implement the holder
+// stuff: we just always pass `this` for the `holder` to callbacks.
+TEST(SpiderShim, GetterHolders) {
+  // Based on the V8 test-api.cc GetterHolders test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> obj = ObjectTemplate::New(isolate);
+  obj->SetAccessor(v8_str("p1"), PGetter);
+  obj->SetAccessor(v8_str("p2"), PGetter);
+  obj->SetAccessor(v8_str("p3"), PGetter);
+  obj->SetAccessor(v8_str("p4"), PGetter);
+  p_getter_count = 0;
+  RunHolderTest(context, obj);
+  ASSERT_EQ(40, p_getter_count);
+}
+#endif
+
+TEST(SpiderShim, ObjectInstantiation) {
+  // Based on the V8 test-api.cc ObjectInstantiation test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> templ = ObjectTemplate::New(isolate);
+  templ->SetAccessor(v8_str("t"), PGetter2);
+  EXPECT_TRUE(context->Global()
+            ->Set(context, v8_str("o"),
+                  templ->NewInstance(context).ToLocalChecked())
+            .FromJust());
+  for (int i = 0; i < 100; i++) {
+    HandleScope inner_scope(isolate);
+    Local<Object> obj =
+        templ->NewInstance(context).ToLocalChecked();
+    EXPECT_TRUE(!obj->Equals(context, context->Global()
+                                            ->Get(context, v8_str("o"))
+                                            .ToLocalChecked())
+               .FromJust());
+    EXPECT_TRUE(
+        context->Global()->Set(context, v8_str("o2"), obj).FromJust());
+    Local<Value> value = CompileRun("o.__proto__ === o2.__proto__");
+    EXPECT_TRUE(True(isolate)->Equals(context, value).FromJust());
+    EXPECT_TRUE(context->Global()->Set(context, v8_str("o"), obj).FromJust());
+  }
+}
+
+static void YGetter(Local<String> name,
+                    const PropertyCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(v8_num(10));
+}
+
+
+static void YSetter(Local<String> name,
+                    Local<Value> value,
+                    const PropertyCallbackInfo<void>& info) {
+  Local<Object> this_obj = Local<Object>::Cast(info.This());
+  Local<Context> context = info.GetIsolate()->GetCurrentContext();
+  if (this_obj->Has(context, name).FromJust())
+    this_obj->Delete(context, name).FromJust();
+  EXPECT_TRUE(this_obj->Set(context, name, value).FromJust());
+}
+
+
+TEST(SpiderShim, DeleteAccessor) {
+  // Based on the V8 test-api.cc DeleteAccessor test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> obj = ObjectTemplate::New(isolate);
+  obj->SetAccessor(v8_str("y"), YGetter, YSetter);
+  Local<Object> holder =
+      obj->NewInstance(context).ToLocalChecked();
+  EXPECT_TRUE(context->Global()
+            ->Set(context, v8_str("holder"), holder)
+            .FromJust());
+  Local<Value> result =
+      CompileRun("holder.y = 11; holder.y = 12; holder.y");
+  EXPECT_EQ(12u, result->Uint32Value(context).FromJust());
+}
+
+static void ParentGetter(Local<String> name,
+                         const PropertyCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(v8_num(1));
+}
+
+
+static void ChildGetter(Local<String> name,
+                        const PropertyCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(v8_num(42));
+}
+
+
+TEST(SpiderShim, Overriding) {
+  // Based on the V8 test-api.cc Overriding test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  // Parent template.
+  Local<FunctionTemplate> parent_templ = FunctionTemplate::New(isolate);
+  Local<ObjectTemplate> parent_instance_templ =
+      parent_templ->InstanceTemplate();
+  parent_instance_templ->SetAccessor(v8_str("f"), ParentGetter);
+
+  // Template that inherits from the parent template.
+  Local<FunctionTemplate> child_templ = FunctionTemplate::New(isolate);
+  Local<ObjectTemplate> child_instance_templ =
+      child_templ->InstanceTemplate();
+  child_templ->Inherit(parent_templ);
+  // Override 'f'.  The child version of 'f' should get called for child
+  // instances.
+  child_instance_templ->SetAccessor(v8_str("f"), ChildGetter);
+  // Add 'g' twice.  The 'g' added last should get called for instances.
+  child_instance_templ->SetAccessor(v8_str("g"), ParentGetter);
+  child_instance_templ->SetAccessor(v8_str("g"), ChildGetter);
+
+  // Add 'h' as an accessor to the proto template with ReadOnly attributes
+  // so 'h' can be shadowed on the instance object.
+  Local<ObjectTemplate> child_proto_templ = child_templ->PrototypeTemplate();
+  child_proto_templ->SetAccessor(v8_str("h"), ParentGetter, 0,
+                                 Local<Value>(), DEFAULT, ReadOnly);
+
+  // Add 'i' as an accessor to the instance template with ReadOnly attributes
+  // but the attribute does not have effect because it is duplicated with
+  // NULL setter.
+  child_instance_templ->SetAccessor(v8_str("i"), ChildGetter, 0,
+                                    Local<Value>(), DEFAULT,
+                                    ReadOnly);
+
+
+  // Instantiate the child template.
+  Local<Object> instance = child_templ->GetFunction(context)
+                                   .ToLocalChecked()
+                                   ->NewInstance(context)
+                                   .ToLocalChecked();
+
+  // Check that the child function overrides the parent one.
+  EXPECT_TRUE(context->Global()
+            ->Set(context, v8_str("o"), instance)
+            .FromJust());
+  Local<Value> value = v8_compile("o.f")->Run(context).ToLocalChecked();
+  // Check that the 'g' that was added last is hit.
+  EXPECT_EQ(42, value->Int32Value(context).FromJust());
+  value = v8_compile("o.g")->Run(context).ToLocalChecked();
+  EXPECT_EQ(42, value->Int32Value(context).FromJust());
+
+  // Check that 'h' cannot be shadowed.
+  value = v8_compile("o.h = 3; o.h")->Run(context).ToLocalChecked();
+  EXPECT_EQ(1, value->Int32Value(context).FromJust());
+
+  // Check that 'i' cannot be shadowed or changed.
+  value = v8_compile("o.i = 3; o.i")->Run(context).ToLocalChecked();
+  EXPECT_EQ(42, value->Int32Value(context).FromJust());
+}
+
+static void GetterWhichReturns42(
+    Local<String> name,
+    const PropertyCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(v8_num(42));
+}
+
+
+static void SetterWhichSetsYOnThisTo23(
+    Local<String> name,
+    Local<Value> value,
+    const PropertyCallbackInfo<void>& info) {
+  Local<Object>::Cast(info.This())
+      ->Set(info.GetIsolate()->GetCurrentContext(), v8_str("y"), v8_num(23))
+      .FromJust();
+}
+
+TEST(SpiderShim, SetterOnConstructorPrototype) {
+  // Based on the V8 test-api.cc SetterOnConstructorPrototype test.
+  V8Engine engine;
+  Isolate* isolate = engine.isolate();
+  Isolate::Scope isolate_scope(isolate);
+
+  HandleScope handle_scope(isolate);
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> templ = ObjectTemplate::New(isolate);
+  templ->SetAccessor(v8_str("x"), GetterWhichReturns42,
+                     SetterWhichSetsYOnThisTo23);
+  EXPECT_TRUE(context->Global()
+            ->Set(context, v8_str("P"),
+                  templ->NewInstance(context).ToLocalChecked())
+            .FromJust());
+  CompileRun("function C1() {"
+             "  this.x = 23;"
+             "};"
+             "C1.prototype = P;"
+             "function C2() {"
+             "  this.x = 23"
+             "};"
+             "C2.prototype = { };"
+             "C2.prototype.__proto__ = P;");
+
+  Local<Script> script;
+  script = v8_compile("new C1();");
+  for (int i = 0; i < 10; i++) {
+    Local<Object> c1 = Local<Object>::Cast(
+        script->Run(context).ToLocalChecked());
+    EXPECT_EQ(42, c1->Get(context, v8_str("x"))
+                     .ToLocalChecked()
+                     ->Int32Value(context)
+                     .FromJust());
+    EXPECT_EQ(23, c1->Get(context, v8_str("y"))
+                     .ToLocalChecked()
+                     ->Int32Value(context)
+                     .FromJust());
+  }
+
+  script = v8_compile("new C2();");
+  for (int i = 0; i < 10; i++) {
+    Local<Object> c2 = Local<Object>::Cast(
+        script->Run(context).ToLocalChecked());
+    EXPECT_EQ(42, c2->Get(context, v8_str("x"))
+                     .ToLocalChecked()
+                     ->Int32Value(context)
+                     .FromJust());
+    EXPECT_EQ(23, c2->Get(context, v8_str("y"))
+                     .ToLocalChecked()
+                     ->Int32Value(context)
+                     .FromJust());
+  }
 }


### PR DESCRIPTION
There are actually three changes here:

1) Replace ASSERT with EXPECT in our test assertions, since the EXPECT version
is what we seem to be using elsewhere.

2) Remove a template.cc test that was duplicated between template.cc and
value.cc.

3) Add the remaining ObjectTemplate tests that don't use stuff we haven't
implemented yet and aren't just exercising JIT weirdness.
