### PR TITLE
Implement signature checking for functions and properties

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2322,8 +2322,7 @@ class V8_EXPORT Signature : public Data {
  public:
   static Local<Signature> New(
       Isolate* isolate,
-      Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>(),
-      int argc = 0, Handle<FunctionTemplate> argv[] = nullptr);
+      Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>());
 
  private:
   Signature();

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2175,6 +2175,9 @@ class V8_EXPORT FunctionTemplate : public Template {
   // InstanceTemplates of all ancestors, on the given object.  Returns false on
   // failure, true on success.
   bool InstallInstanceProperties(Local<Object> target);
+  // Performs a signature check if needed.  Returns true and a holder object
+  // unless the signature check fails.
+  bool CheckSignature(Local<Object> _this, Local<Object>& holder);
 };
 
 enum class PropertyHandlerFlags {

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -770,6 +770,7 @@ class V8_EXPORT HandleScope {
 
   static Value* AddToScope(Value* val);
   static Template* AddToScope(Template* val);
+  static Signature* AddToScope(Signature* val);
   static Script* AddToScope(JSScript* script, Local<Context> context);
   static Private* AddToScope(JS::Symbol* priv);
   static Message* AddToScope(Message* msg);
@@ -2325,8 +2326,13 @@ class V8_EXPORT Signature : public Data {
       Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>());
 
  private:
-  Signature();
+  // We treat signatures as JS::Values containing a FunctionTemplate, and we
+  // root them in the same way that we root v8::Value.
+  // TODO: Consider lifting this up into v8::Data once we have implemented
+  // all of the Data subclasses.
+  char spidershim_padding[8];
 };
+static_assert(sizeof(v8::Signature) == 8, "v8::Signature must be the same size as JS::Value");
 
 class V8_EXPORT AccessorSignature : public Data {
  public:

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -771,6 +771,7 @@ class V8_EXPORT HandleScope {
   static Value* AddToScope(Value* val);
   static Template* AddToScope(Template* val);
   static Signature* AddToScope(Signature* val);
+  static AccessorSignature* AddToScope(AccessorSignature* val);
   static Script* AddToScope(JSScript* script, Local<Context> context);
   static Private* AddToScope(JS::Symbol* priv);
   static Message* AddToScope(Message* msg);
@@ -2342,7 +2343,15 @@ class V8_EXPORT AccessorSignature : public Data {
   static Local<AccessorSignature> New(
       Isolate* isolate,
       Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>());
+
+ private:
+  // We treat signatures as JS::Values containing a FunctionTemplate, and we
+  // root them in the same way that we root v8::Value.
+  // TODO: Consider lifting this up into v8::Data once we have implemented
+  // all of the Data subclasses.
+  char spidershim_padding[8];
 };
+static_assert(sizeof(v8::AccessorSignature) == 8, "v8::AccessorSignature must be the same size as JS::Value");
 
 // --- Promise Reject Callback ---
 enum PromiseRejectEvent {

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -144,6 +144,7 @@ template <typename T>
 struct ExternalStringFinalizerBase;
 struct ExternalStringFinalizer;
 struct ExternalOneByteStringFinalizer;
+struct SignatureChecker;
 }
 
 enum PropertyAttribute {
@@ -2281,6 +2282,7 @@ class V8_EXPORT ObjectTemplate : public Template {
  private:
   friend struct FunctionCallbackData;
   friend struct FunctionTemplateData;
+  friend struct internal::SignatureChecker;
   friend class Utils;
   friend class FunctionTemplate;
 

--- a/deps/spidershim/spidershim.gyp
+++ b/deps/spidershim/spidershim.gyp
@@ -88,6 +88,7 @@
         'src/v8proxy.cc',
         'src/v8script.cc',
         'src/v8scriptcompiler.cc',
+        'src/v8signature.cc',
         'src/v8stackframe.cc',
         'src/v8stacktrace.cc',
         'src/v8string.cc',

--- a/deps/spidershim/src/accessor.h
+++ b/deps/spidershim/src/accessor.h
@@ -25,6 +25,11 @@
 #include "v8.h"
 #include "v8local.h"
 
+namespace {
+
+const char* kIllegalInvocation = "Illegal invocation";
+}
+
 namespace v8 {
 namespace internal {
 
@@ -47,6 +52,7 @@ enum class AccessorSlots {
   DataSlot,
   CallbackSlot1,
   CallbackSlot2,
+  SignatureSlot,
   NumSlots
 };
 
@@ -101,6 +107,30 @@ struct CallbackTraits<typename XerTraits<N>::Setter, N> {
   static const unsigned nargs = 0;
 };
 
+struct SignatureChecker {
+  // Performs a signature check if needed.  Returns true and a holder object
+  // unless the signature check fails.
+  static bool CheckSignature(JS::HandleObject accessorData,
+                             v8::Local<Object> _this,
+                             v8::Local<Object>& holder) {
+    Isolate* isolate = Isolate::GetCurrent();
+    JSContext* cx = JSContextFromIsolate(isolate);
+    AutoJSAPI jsAPI(cx, GetObject(_this));
+    assert(JS_GetClass(accessorData) == &accessorDataClass);
+    JS::Value signatureVal = js::GetReservedSlot(accessorData,
+                                                 size_t(AccessorSlots::SignatureSlot));
+    if (!signatureVal.isUndefined()) {
+      v8::Local<FunctionTemplate> signatureAsTemplate =
+        internal::Local<FunctionTemplate>::NewTemplate(isolate, signatureVal);
+      if (!signatureAsTemplate->InstanceTemplate()->IsInstance(GetObject(_this))) {
+        return false;
+      }
+    }
+    holder = _this;
+    return true;
+  }
+};
+
 // AccessorGetterCallback/AccessorSetterCallback are passed information that is
 // not really present in SpiderMonkey: a Local<String> for the property name
 // (directly) and a Value for the callback data (indirectly, via
@@ -137,13 +167,16 @@ bool NativeAccessorCallback(JSContext* cx, unsigned argc, JS::Value* vp) {
   auto callback =
     ValuesToCallback<CallbackType>(callbackVal1, callbackVal2);
   if (callback) {
-    // TODO: Figure out the story for holder.  See
-    // https://groups.google.com/d/msg/v8-users/Axf4hF_RfZo/hA6Mvo78AqAJ (which is
-    // kinda messed up, since they have _stopped_ doing the weird holder thing for
-    // DOM stuff since then).
+    v8::Local<Object> holder;
+    if (!SignatureChecker::CheckSignature(accessorData, thisObject, holder)) {
+      isolate->ThrowException(
+          Exception::Error(String::NewFromUtf8(isolate,
+                                               kIllegalInvocation)));
+      return false;
+    }
     typedef typename
       CallbackTraits<CallbackType, N>::PropertyCallbackInfo PropertyCallbackInfo;
-    PropertyCallbackInfo info(data, thisObject, thisObject);
+    PropertyCallbackInfo info(data, thisObject, holder);
 
     CallbackTraits<CallbackType, N>::doCall(isolate, callback, name,
                                             info, args);
@@ -159,7 +192,8 @@ bool NativeAccessorCallback(JSContext* cx, unsigned argc, JS::Value* vp) {
 template<typename CallbackType, class N>
 JSObject* CreateAccessor(JSContext* cx, CallbackType callback,
                          v8::Handle<N> name,
-                         v8::Handle<v8::Value> data) {
+                         v8::Handle<v8::Value> data,
+                         v8::Handle<v8::AccessorSignature> signature) {
   // XXXbz should we pass a better name here?
   JSFunction* func =
     js::NewFunctionWithReserved(cx, NativeAccessorCallback<CallbackType, N>,
@@ -194,6 +228,14 @@ JSObject* CreateAccessor(JSContext* cx, CallbackType callback,
   js::SetReservedSlot(accessorData, size_t(AccessorSlots::CallbackSlot2),
                       callbackVal2);
 
+  JS::Value signatureVal;
+  signatureVal.setUndefined();
+  if (!signature.IsEmpty()) {
+    signatureVal = *GetValue(signature);
+  }
+  js::SetReservedSlot(accessorData, size_t(AccessorSlots::SignatureSlot),
+                      signatureVal);
+
   return funObj;
 }
 
@@ -211,13 +253,13 @@ bool SetAccessor(JSContext* cx,
   // TODO: What should happen with "settings", "signature"?  See
   // https://github.com/mozilla/spidernode/issues/141
 
-  JS::RootedObject getterObj(cx, CreateAccessor(cx, getter, name, data));
+  JS::RootedObject getterObj(cx, CreateAccessor(cx, getter, name, data, signature));
   if (!getterObj) {
     return false;
   }
   JS::RootedObject setterObj(cx);
   if (setter) {
-    setterObj = CreateAccessor(cx, setter, name, data);
+    setterObj = CreateAccessor(cx, setter, name, data, signature);
     if (!setterObj) {
       return false;
     }

--- a/deps/spidershim/src/conversions.h
+++ b/deps/spidershim/src/conversions.h
@@ -45,6 +45,14 @@ static inline const JS::Value* GetValue(const Template* val) {
   return reinterpret_cast<const JS::Value*>(val);
 }
 
+static inline JS::Value* GetValue(Signature* val) {
+  return reinterpret_cast<JS::Value*>(val);
+}
+
+static inline const JS::Value* GetValue(const Signature* val) {
+  return reinterpret_cast<const JS::Value*>(val);
+}
+
 static inline Value* GetV8Value(JS::Value* val) {
   return reinterpret_cast<Value*>(val);
 }
@@ -67,6 +75,18 @@ static inline const Value* GetV8Value(const Template* val) {
 
 static inline Template* GetV8Template(JS::Value* val) {
   return reinterpret_cast<Template*>(val);
+}
+
+static inline Value* GetV8Value(Signature* val) {
+  return GetV8Value(GetValue(val));
+}
+
+static inline const Value* GetV8Value(const Signature* val) {
+  return GetV8Value(GetValue(val));
+}
+
+static inline Signature* GetV8Signature(JS::Value* val) {
+  return reinterpret_cast<Signature*>(val);
 }
 
 static inline JSObject* GetObject(Value* val) {

--- a/deps/spidershim/src/conversions.h
+++ b/deps/spidershim/src/conversions.h
@@ -53,6 +53,14 @@ static inline const JS::Value* GetValue(const Signature* val) {
   return reinterpret_cast<const JS::Value*>(val);
 }
 
+static inline JS::Value* GetValue(AccessorSignature* val) {
+  return reinterpret_cast<JS::Value*>(val);
+}
+
+static inline const JS::Value* GetValue(const AccessorSignature* val) {
+  return reinterpret_cast<const JS::Value*>(val);
+}
+
 static inline Value* GetV8Value(JS::Value* val) {
   return reinterpret_cast<Value*>(val);
 }
@@ -87,6 +95,18 @@ static inline const Value* GetV8Value(const Signature* val) {
 
 static inline Signature* GetV8Signature(JS::Value* val) {
   return reinterpret_cast<Signature*>(val);
+}
+
+static inline Value* GetV8Value(AccessorSignature* val) {
+  return GetV8Value(GetValue(val));
+}
+
+static inline const Value* GetV8Value(const AccessorSignature* val) {
+  return GetV8Value(GetValue(val));
+}
+
+static inline AccessorSignature* GetV8AccessorSignature(JS::Value* val) {
+  return reinterpret_cast<AccessorSignature*>(val);
 }
 
 static inline JSObject* GetObject(Value* val) {

--- a/deps/spidershim/src/rootstore.h
+++ b/deps/spidershim/src/rootstore.h
@@ -70,6 +70,11 @@ class RootStore {
     return GetV8Template(&values.back());
   }
 
+  Signature* Add(Signature* val) {
+    values.push_back(*GetValue(val));
+    return GetV8Signature(&values.back());
+  }
+
   // T can be any type that GetValue() can convert to a JS::Value*,
   // for example v8::Value or v8::Template.
   template <class T>

--- a/deps/spidershim/src/rootstore.h
+++ b/deps/spidershim/src/rootstore.h
@@ -75,6 +75,11 @@ class RootStore {
     return GetV8Signature(&values.back());
   }
 
+  AccessorSignature* Add(AccessorSignature* val) {
+    values.push_back(*GetValue(val));
+    return GetV8AccessorSignature(&values.back());
+  }
+
   // T can be any type that GetValue() can convert to a JS::Value*,
   // for example v8::Value or v8::Template.
   template <class T>

--- a/deps/spidershim/src/v8function.cc
+++ b/deps/spidershim/src/v8function.cc
@@ -26,12 +26,11 @@
 #include "jsapi.h"
 #include "jsfriendapi.h"
 #include "js/Conversions.h"
+#include "accessor.h"
 
 namespace {
 
 using namespace v8;
-
-const char* kIllegalInvocation = "Illegal invocation";
 
 // For now, we implement the hidden callee data using a property with a symbol
 // key. This is observable to script, so if this becomes an issue in the future

--- a/deps/spidershim/src/v8handlescope.cc
+++ b/deps/spidershim/src/v8handlescope.cc
@@ -88,6 +88,13 @@ Signature* HandleScope::AddToScope(Signature* val) {
   return sCurrentScope.get()->pimpl_->Add(val);
 }
 
+AccessorSignature* HandleScope::AddToScope(AccessorSignature* val) {
+  if (!sCurrentScope.get()) {
+    return nullptr;
+  }
+  return sCurrentScope.get()->pimpl_->Add(val);
+}
+
 Script* HandleScope::AddToScope(JSScript* script, Local<Context> context) {
   if (!sCurrentScope.get()) {
     return nullptr;

--- a/deps/spidershim/src/v8handlescope.cc
+++ b/deps/spidershim/src/v8handlescope.cc
@@ -81,6 +81,13 @@ Template* HandleScope::AddToScope(Template* val) {
   return sCurrentScope.get()->pimpl_->Add(val);
 }
 
+Signature* HandleScope::AddToScope(Signature* val) {
+  if (!sCurrentScope.get()) {
+    return nullptr;
+  }
+  return sCurrentScope.get()->pimpl_->Add(val);
+}
+
 Script* HandleScope::AddToScope(JSScript* script, Local<Context> context) {
   if (!sCurrentScope.get()) {
     return nullptr;

--- a/deps/spidershim/src/v8local.h
+++ b/deps/spidershim/src/v8local.h
@@ -42,6 +42,9 @@ class Local {
   static v8::Local<T> NewSignature(Isolate* isolate, JS::Value val) {
     return v8::Local<T>::New(isolate, GetV8Signature(&val));
   }
+  static v8::Local<T> NewAccessorSignature(Isolate* isolate, JS::Value val) {
+    return v8::Local<T>::New(isolate, GetV8AccessorSignature(&val));
+  }
 };
 }
 }

--- a/deps/spidershim/src/v8signature.cc
+++ b/deps/spidershim/src/v8signature.cc
@@ -36,4 +36,14 @@ Local<Signature> Signature::New(Isolate* isolate,
   }
   return internal::Local<Signature>::NewSignature(isolate, signatureVal);
 }
+
+Local<AccessorSignature> AccessorSignature::New(Isolate* isolate,
+                                                Local<FunctionTemplate> receiver) {
+  JS::Value signatureVal;
+  signatureVal.setUndefined();
+  if (!receiver.IsEmpty()) {
+    signatureVal = *GetValue(receiver);
+  }
+  return internal::Local<AccessorSignature>::NewAccessorSignature(isolate, signatureVal);
+}
 }

--- a/deps/spidershim/src/v8signature.cc
+++ b/deps/spidershim/src/v8signature.cc
@@ -18,30 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#pragma once
+#include <assert.h>
+
+#include "v8.h"
+#include "jsapi.h"
 #include "conversions.h"
+#include "v8local.h"
 
 namespace v8 {
-namespace internal {
 
-template <class T>
-class Local {
- public:
-  static v8::Local<T> New(Isolate* isolate, JS::Value val) {
-    return v8::Local<T>::New(isolate, GetV8Value(&val));
+Local<Signature> Signature::New(Isolate* isolate,
+                                Local<FunctionTemplate> receiver) {
+  JS::Value signatureVal;
+  signatureVal.setUndefined();
+  if (!receiver.IsEmpty()) {
+    signatureVal = *GetValue(receiver);
   }
-  static v8::Local<T> New(Isolate* isolate, JSScript* script, v8::Local<Context> context) {
-    return v8::Local<T>::New(isolate, script, context);
-  }
-  static v8::Local<T> New(Isolate* isolate, JS::Symbol* symbol) {
-    return v8::Local<T>::New(isolate, symbol);
-  }
-  static v8::Local<T> NewTemplate(Isolate* isolate, JS::Value val) {
-    return v8::Local<T>::New(isolate, GetV8Template(&val));
-  }
-  static v8::Local<T> NewSignature(Isolate* isolate, JS::Value val) {
-    return v8::Local<T>::New(isolate, GetV8Signature(&val));
-  }
-};
+  return internal::Local<Signature>::NewSignature(isolate, signatureVal);
 }
 }

--- a/deps/spidershim/test/template.cc
+++ b/deps/spidershim/test/template.cc
@@ -388,9 +388,6 @@ TEST(SpiderShim, FunctionTemplateSetLength) {
 }
 
 
-// Need support for Signature to do FunctionTemplateReceiverSignature.  See
-// https://github.com/mozilla/spidernode/issues/144
-#if 0
 static int signature_callback_count;
 static Local<Value> signature_expected_receiver;
 static void IncrementingSignatureCallback(
@@ -441,6 +438,7 @@ static void TestSignature(V8Engine& engine, Local<Context> context,
   }
 }
 
+#if 0
 TEST(SpiderShim, FunctionTemplateReceiverSignature) {
   // Largely stolen from the V8 test-api.cc ReceiverSignature test.
   V8Engine engine;

--- a/deps/spidershim/test/template.cc
+++ b/deps/spidershim/test/template.cc
@@ -687,11 +687,9 @@ TEST(SpiderShim, InstanceCheckOnInstanceAccessor) {
 
   Local<FunctionTemplate> templ = FunctionTemplate::New(context->GetIsolate());
   Local<ObjectTemplate> inst = templ->InstanceTemplate();
-  // TODO: Uncomment once we implement signatures.
-  // See https://github.com/mozilla/spidernode/issues/144.
   inst->SetAccessor(v8_str("foo"), InstanceCheckedGetter, InstanceCheckedSetter,
-                    Local<Value>(), v8::DEFAULT, v8::None/*,
-                    v8::AccessorSignature::New(context->GetIsolate(), templ)*/);
+                    Local<Value>(), v8::DEFAULT, v8::None,
+                    v8::AccessorSignature::New(context->GetIsolate(), templ));
   EXPECT_TRUE(context->Global()
             ->Set(context, v8_str("f"),
                   templ->GetFunction(context).ToLocalChecked())
@@ -706,9 +704,7 @@ TEST(SpiderShim, InstanceCheckOnInstanceAccessor) {
              "obj.__proto__ = new f();");
   EXPECT_TRUE(!templ->HasInstance(
       context->Global()->Get(context, v8_str("obj")).ToLocalChecked()));
-  // TODO: Once we implement signatures, we should be passing false to CheckInstanceCheckedAccessors.
-  // CheckInstanceCheckedAccessors(false);
-  CheckInstanceCheckedAccessors(true);
+  CheckInstanceCheckedAccessors(false);
 }
 
 TEST(SpiderShim, InstanceCheckOnPrototypeAccessor) {
@@ -722,12 +718,10 @@ TEST(SpiderShim, InstanceCheckOnPrototypeAccessor) {
 
   Local<FunctionTemplate> templ = FunctionTemplate::New(context->GetIsolate());
   Local<ObjectTemplate> proto = templ->PrototypeTemplate();
-  // TODO: Uncomment once we implement signatures.
-  // See https://github.com/mozilla/spidernode/issues/144.
   proto->SetAccessor(v8_str("foo"), InstanceCheckedGetter,
                      InstanceCheckedSetter, Local<Value>(), v8::DEFAULT,
-                     v8::None/*,
-                     v8::AccessorSignature::New(context->GetIsolate(), templ)*/);
+                     v8::None,
+                     v8::AccessorSignature::New(context->GetIsolate(), templ));
   EXPECT_TRUE(context->Global()
             ->Set(context, v8_str("f"),
                   templ->GetFunction(context).ToLocalChecked())
@@ -742,9 +736,7 @@ TEST(SpiderShim, InstanceCheckOnPrototypeAccessor) {
              "obj.__proto__ = new f();");
   EXPECT_TRUE(!templ->HasInstance(
       context->Global()->Get(context, v8_str("obj")).ToLocalChecked()));
-  // TODO: Once we implement signatures, we should be passing false to CheckInstanceCheckedAccessors.
-  // CheckInstanceCheckedAccessors(false);
-  CheckInstanceCheckedAccessors(true);
+  CheckInstanceCheckedAccessors(false);
 
   CompileRun("var obj = new f();"
              "var pro = {};"


### PR DESCRIPTION
This fixes #144.  For reviewing, it probably helps to read the individual commits in order.  The last two are the logical equivalent of the second and third commits, but for properties instead of functions.

@bzbarsky can you please review?  Thanks!
