### PR TITLE
Implement {Object,Template}::SetAccessorProperty

### DIFF
--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2167,6 +2167,13 @@ class V8_EXPORT Template : public Data {
     Set(v8::String::NewFromUtf8(isolate, name), value);
   }
 
+  void SetAccessorProperty(
+     Local<Name> name,
+     Local<FunctionTemplate> getter = Local<FunctionTemplate>(),
+     Local<FunctionTemplate> setter = Local<FunctionTemplate>(),
+     PropertyAttribute attribute = None,
+     AccessControl settings = DEFAULT);
+
  protected:
   // Callers are expected to put the JSContext in the right compartment before
   // calling this function.

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -2201,6 +2201,7 @@ class V8_EXPORT FunctionTemplate : public Template {
 
  private:
   friend class internal::FunctionCallback;
+  friend struct internal::SignatureChecker;
   friend class Template;
   friend class ObjectTemplate;
 
@@ -2230,6 +2231,9 @@ class V8_EXPORT FunctionTemplate : public Template {
   // unless the signature check fails.  thisObj should be set to the this object
   // that the function is being called on.
   bool CheckSignature(Local<Object> thisObj, Local<Object>& holder);
+  // Returns true if thisObj has been instantiated from this FunctionTemplate
+  // or one inherited from this one.
+  bool IsInstance(Local<Object> thisObj);
 };
 
 enum class PropertyHandlerFlags {
@@ -2332,7 +2336,6 @@ class V8_EXPORT ObjectTemplate : public Template {
  private:
   friend struct FunctionCallbackData;
   friend struct FunctionTemplateData;
-  friend struct internal::SignatureChecker;
   friend class Utils;
   friend class FunctionTemplate;
 
@@ -2355,7 +2358,6 @@ class V8_EXPORT ObjectTemplate : public Template {
   // one.  Null is returned if objects should be created with the default
   // plain-object JSClass.
   InstanceClass* GetInstanceClass();
-  bool IsInstance(JSObject* obj);
   static bool IsObjectFromTemplate(Local<Object> object);
   // The object argument should be an object created from an ObjectTemplate,
   // i.e.,

--- a/deps/spidershim/include/v8.h
+++ b/deps/spidershim/include/v8.h
@@ -1578,6 +1578,11 @@ class V8_EXPORT Object : public Value {
                           AccessControl settings = DEFAULT,
                           PropertyAttribute attribute = None);
 
+  void SetAccessorProperty(Local<Name> name, Local<Function> getter,
+                           Local<Function> setter = Local<Function>(),
+                           PropertyAttribute attribute = None,
+                           AccessControl settings = DEFAULT);
+
   V8_DEPRECATE_SOON("Use maybe version", Local<Array> GetPropertyNames());
   V8_WARN_UNUSED_RESULT MaybeLocal<Array> GetPropertyNames(
       Local<Context> context);

--- a/deps/spidershim/src/accessor.h
+++ b/deps/spidershim/src/accessor.h
@@ -171,8 +171,8 @@ bool NativeAccessorCallback(JSContext* cx, unsigned argc, JS::Value* vp) {
     v8::Local<Object> holder;
     if (!SignatureChecker::CheckSignature(accessorData, thisObject, holder)) {
       isolate->ThrowException(
-          Exception::Error(String::NewFromUtf8(isolate,
-                                               kIllegalInvocation)));
+          Exception::TypeError(String::NewFromUtf8(isolate,
+                                                   kIllegalInvocation)));
       return false;
     }
     typedef typename

--- a/deps/spidershim/src/accessor.h
+++ b/deps/spidershim/src/accessor.h
@@ -240,6 +240,36 @@ JSObject* CreateAccessor(JSContext* cx, CallbackType callback,
   return funObj;
 }
 
+template<class N>
+bool SetAccessor(JSContext* cx,
+                 JS::HandleObject obj,
+                 Handle<N> name,
+                 JSObject* getter,
+                 JSObject* setter,
+                 AccessControl settings,
+                 PropertyAttribute attribute) {
+  JS::RootedId id(cx);
+  JS::RootedValue nameVal(cx, *GetValue(name));
+  if (!JS_WrapValue(cx, &nameVal) ||
+      !JS_ValueToId(cx, nameVal, &id)) {
+    return false;
+  }
+
+  unsigned attrs = internal::AttrsToFlags(attribute) |
+                   JSPROP_SHARED | JSPROP_GETTER;
+  if (setter) {
+    attrs |= JSPROP_SETTER;
+  }
+
+  if (!JS_DefinePropertyById(cx, obj, id, JS::UndefinedHandleValue, attrs,
+                             JS_DATA_TO_FUNC_PTR(JSNative, getter),
+                             JS_DATA_TO_FUNC_PTR(JSNative, setter))) {
+    return false;
+  }
+
+  return true;
+}
+
 template<class N, class Getter, class Setter>
 bool SetAccessor(JSContext* cx,
                  JS::HandleObject obj,
@@ -254,11 +284,11 @@ bool SetAccessor(JSContext* cx,
   // TODO: What should happen with "settings"?  See
   // https://github.com/mozilla/spidernode/issues/141
 
-  JS::RootedObject getterObj(cx, CreateAccessor(cx, getter, name, data, signature));
+  JSObject* getterObj = CreateAccessor(cx, getter, name, data, signature);
   if (!getterObj) {
     return false;
   }
-  JS::RootedObject setterObj(cx);
+  JSObject* setterObj = nullptr;
   if (setter) {
     setterObj = CreateAccessor(cx, setter, name, data, signature);
     if (!setterObj) {
@@ -266,23 +296,8 @@ bool SetAccessor(JSContext* cx,
     }
   }
 
-  JS::RootedId id(cx);
-  JS::RootedValue nameVal(cx, *GetValue(name));
-  if (!JS_WrapValue(cx, &nameVal) ||
-      !JS_ValueToId(cx, nameVal, &id)) {
-    return false;
-  }
-
-  unsigned attrs = internal::AttrsToFlags(attribute) |
-                   JSPROP_SHARED | JSPROP_GETTER | JSPROP_SETTER;
-
-  if (!JS_DefinePropertyById(cx, obj, id, JS::UndefinedHandleValue, attrs,
-                             JS_DATA_TO_FUNC_PTR(JSNative, getterObj.get()),
-                             JS_DATA_TO_FUNC_PTR(JSNative, setterObj.get()))) {
-    return false;
-  }
-
-  return true;
+  return SetAccessor(cx, obj, name, getterObj, setterObj, settings,
+                     attribute);
 }
 
 }

--- a/deps/spidershim/src/accessor.h
+++ b/deps/spidershim/src/accessor.h
@@ -123,7 +123,7 @@ struct SignatureChecker {
     if (!signatureVal.isUndefined()) {
       v8::Local<FunctionTemplate> signatureAsTemplate =
         internal::Local<FunctionTemplate>::NewTemplate(isolate, signatureVal);
-      if (!signatureAsTemplate->InstanceTemplate()->IsInstance(GetObject(thisObj))) {
+      if (!signatureAsTemplate->IsInstance(thisObj)) {
         return false;
       }
     }

--- a/deps/spidershim/src/v8function.cc
+++ b/deps/spidershim/src/v8function.cc
@@ -166,8 +166,8 @@ class FunctionCallback {
       } else {
         if (!templ->CheckSignature(_this, holder)) {
           isolate->ThrowException(
-              Exception::Error(String::NewFromUtf8(isolate,
-                                                   kIllegalInvocation)));
+              Exception::TypeError(String::NewFromUtf8(isolate,
+                                                       kIllegalInvocation)));
           return false;
         }
       }

--- a/deps/spidershim/src/v8object.cc
+++ b/deps/spidershim/src/v8object.cc
@@ -813,4 +813,17 @@ Maybe<bool> Object::SetAccessorInternal(JSContext* cx,
   }
   return Just(true);
 }
+
+void Object::SetAccessorProperty(Local<Name> name, Local<Function> getter,
+                                 Local<Function> setter, PropertyAttribute attribute,
+                                 AccessControl settings) {
+  Isolate* isolate = Isolate::GetCurrent();
+  JSContext* cx = JSContextFromIsolate(isolate);
+  AutoJSAPI jsAPI(cx, this);
+  JS::RootedObject obj(cx, GetObject(this));
+
+  internal::SetAccessor(cx, obj, name, GetObject(getter),
+                        setter.IsEmpty() ? nullptr : GetObject(setter),
+                        settings, attribute);
+}
 }

--- a/deps/spidershim/src/v8objecttemplate.cc
+++ b/deps/spidershim/src/v8objecttemplate.cc
@@ -379,12 +379,6 @@ void ObjectTemplate::SetInternalFieldCount(int value) {
                       JS::Int32Value(value));
 }
 
-bool ObjectTemplate::IsInstance(JSObject* obj) {
-  InstanceClass* instanceClass = GetInstanceClass();
-  assert(instanceClass);
-  return JS_GetClass(obj) == instanceClass;
-}
-
 Local<FunctionTemplate> ObjectTemplate::GetConstructor() {
   Isolate* isolate = Isolate::GetCurrent();
   JSContext* cx = JSContextFromIsolate(isolate);

--- a/deps/spidershim/src/v8template.cc
+++ b/deps/spidershim/src/v8template.cc
@@ -22,6 +22,8 @@
 
 #include "conversions.h"
 #include "jsapi.h"
+#include "jsfriendapi.h"
+#include "accessor.h"
 #include "v8local.h"
 
 namespace v8 {
@@ -45,5 +47,20 @@ void Template::Set(Local<String> name, Local<Data> value,
   Local<Value> val =
     FunctionTemplate::MaybeConvertObjectProperty(value.As<Value>(), name);
   thisObj->ForceSet(name, val, attributes);
+}
+
+void Template::SetAccessorProperty(Local<Name> name,
+                                   Local<FunctionTemplate> getter,
+                                   Local<FunctionTemplate> setter,
+                                   PropertyAttribute attribute,
+                                   AccessControl settings) {
+  Isolate* isolate = Isolate::GetCurrent();
+  JSContext* cx = JSContextFromIsolate(isolate);
+  AutoJSAPI jsAPI(cx, this);
+  JS::RootedObject obj(cx, GetObject(this));
+
+  internal::SetAccessor(cx, obj, name, GetObject(getter->GetFunction()),
+                        setter.IsEmpty() ? nullptr : GetObject(setter->GetFunction()),
+                        settings, attribute);
 }
 }

--- a/deps/spidershim/test/template.cc
+++ b/deps/spidershim/test/template.cc
@@ -74,10 +74,7 @@ TEST(SpiderShim, ObjectTemplateDetails) {
   templ2->Set(isolate, "a", v8_num(12));
      templ2->Set(isolate, "b", templ1);
      templ2->Set(v8_str("bar"), acc);
-  // TEST_TODO: accessors on ObjectTemplate are totally different in node vs tip
-  // V8, so test SetAccessor instead of SetAccessorProperty
-  //   templ2->SetAccessorProperty(v8_str("acc"), acc);
-  templ2->SetAccessor(v8_str("acc"), Gets42);
+  templ2->SetAccessorProperty(v8_str("acc"), acc);
   Local<Object> instance2 =
     templ2->NewInstance(context).ToLocalChecked();
   EXPECT_TRUE(context->Global()->Set(context, v8_str("q"), instance2).FromJust());
@@ -130,17 +127,16 @@ TEST(SpiderShim, ObjectTemplateDetails) {
   //             ->BooleanValue(context)
   //             .FromJust());
 
-  // TEST_TORO: Enable this part when we switch to SetAccessorProperty() above.
-  //  EXPECT_TRUE(engine.CompileRun(context,
-  //                      "desc1 = Object.getOwnPropertyDescriptor(q, 'acc');"
-  //                      "(desc1.get === acc)")
-  //                 ->BooleanValue(context)
-  //                 .FromJust());
-  //  EXPECT_TRUE(engine.CompileRun(context,
-  //                          "desc2 = Object.getOwnPropertyDescriptor(q2, 'acc');"
-  //                          "(desc2.get === acc)")
-  //            ->BooleanValue(context)
-  //            .FromJust());
+  EXPECT_TRUE(engine.CompileRun(context,
+                      "desc1 = Object.getOwnPropertyDescriptor(q, 'acc');"
+                      "(desc1.get === acc)")
+                 ->BooleanValue(context)
+                 .FromJust());
+  EXPECT_TRUE(engine.CompileRun(context,
+                          "desc2 = Object.getOwnPropertyDescriptor(q2, 'acc');"
+                          "(desc2.get === acc)")
+            ->BooleanValue(context)
+            .FromJust());
 }
 
 static void GetNirk(Local<String> name,
@@ -438,7 +434,6 @@ static void TestSignature(V8Engine& engine, Local<Context> context,
   }
 }
 
-#if 0
 TEST(SpiderShim, FunctionTemplateReceiverSignature) {
   // Largely stolen from the V8 test-api.cc ReceiverSignature test.
   V8Engine engine;
@@ -463,11 +458,9 @@ TEST(SpiderShim, FunctionTemplateReceiverSignature) {
   v8::Local<v8::ObjectTemplate> fun_proto = fun->PrototypeTemplate();
   fun_proto->Set(v8_str("prop_sig"), callback_sig);
   fun_proto->Set(v8_str("prop"), callback);
-  // No support for SetAccessorProperty yet (and indeed, it doesn't even exist
-  // in our V8 version).
-  // fun_proto->SetAccessorProperty(
-  //     v8_str("accessor_sig"), callback_sig, callback_sig);
-  // fun_proto->SetAccessorProperty(v8_str("accessor"), callback, callback);
+  fun_proto->SetAccessorProperty(
+      v8_str("accessor_sig"), callback_sig, callback_sig);
+  fun_proto->SetAccessorProperty(v8_str("accessor"), callback, callback);
 
   // Instantiate templates.
   Local<Value> fun_instance =
@@ -540,7 +533,6 @@ TEST(SpiderShim, FunctionTemplateReceiverSignature) {
                   "test_object[accessor_sig_key] = 1;", test_object, isolate);
   }
 }
-#endif // FunctionTemplateReceiverSignature
 
 TEST(SpiderShim, InternalFields) {
   // Loosely based on the V8 test-api.cc InternalFields test.


### PR DESCRIPTION
These commits are mostly straightforward.  The most interesting part is the second commit, which fixes our signature checking to support checking an object created from `FunctionTemplate` B inherited from A when the signature check is performed on A.  This case is examined by the `sub_fun_instance` test inside `FunctionTemplateReceiverSignature`.

@bzbarsky can you please review?  Thanks!
