### PR TITLE
remove #include_next directive

### DIFF
--- a/deps/spidershim/src/accessor.h
+++ b/deps/spidershim/src/accessor.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <assert.h>
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "v8.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/autojsapi.h
+++ b/deps/spidershim/src/autojsapi.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include_next <jsapi.h>
+#include <jsapi.h>
 #include <assert.h>
 #include "v8.h"
 #include "conversions.h"

--- a/deps/spidershim/src/gclist.h
+++ b/deps/spidershim/src/gclist.h
@@ -23,7 +23,7 @@
 #include <list>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/GCPolicyAPI.h"
 
 namespace v8 {

--- a/deps/spidershim/src/utils.h
+++ b/deps/spidershim/src/utils.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Proxy.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/v8array.cc
+++ b/deps/spidershim/src/v8array.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Class.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8arraybuffer.cc
+++ b/deps/spidershim/src/v8arraybuffer.cc
@@ -22,7 +22,7 @@
 #include "v8conversions.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/Conversions.h"
 

--- a/deps/spidershim/src/v8arraybufferview.cc
+++ b/deps/spidershim/src/v8arraybufferview.cc
@@ -21,7 +21,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8boolean.cc
+++ b/deps/spidershim/src/v8boolean.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "conversions.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/v8booleanobject.cc
+++ b/deps/spidershim/src/v8booleanobject.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Class.h"
 #include "js/Conversions.h"
 #include "conversions.h"

--- a/deps/spidershim/src/v8context.cc
+++ b/deps/spidershim/src/v8context.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "v8context.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "instanceslots.h"
 #include "spidershim_natives.h"

--- a/deps/spidershim/src/v8context.h
+++ b/deps/spidershim/src/v8context.h
@@ -20,7 +20,7 @@
 
 #pragma once
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include <vector>
 #include <utility>
 

--- a/deps/spidershim/src/v8date.cc
+++ b/deps/spidershim/src/v8date.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Date.h"
 #include "conversions.h"
 #include "v8local.h"

--- a/deps/spidershim/src/v8exception.cc
+++ b/deps/spidershim/src/v8exception.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace {

--- a/deps/spidershim/src/v8external.cc
+++ b/deps/spidershim/src/v8external.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "conversions.h"
 #include "v8local.h"

--- a/deps/spidershim/src/v8function.cc
+++ b/deps/spidershim/src/v8function.cc
@@ -23,7 +23,7 @@
 #include "v8conversions.h"
 #include "v8local.h"
 #include "v8trycatch.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/Conversions.h"
 #include "accessor.h"

--- a/deps/spidershim/src/v8functiontemplate.cc
+++ b/deps/spidershim/src/v8functiontemplate.cc
@@ -22,7 +22,7 @@
 
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "utils.h"
 

--- a/deps/spidershim/src/v8global.cc
+++ b/deps/spidershim/src/v8global.cc
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "v8local.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8handlescope.cc
+++ b/deps/spidershim/src/v8handlescope.cc
@@ -23,7 +23,7 @@
 
 #include "v8.h"
 #include "v8handlescope.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "rootstore.h"
 #include "mozilla/ThreadLocal.h"
 

--- a/deps/spidershim/src/v8int32.cc
+++ b/deps/spidershim/src/v8int32.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 
 namespace v8 {
 

--- a/deps/spidershim/src/v8integer.cc
+++ b/deps/spidershim/src/v8integer.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "conversions.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/v8isolate.cc
+++ b/deps/spidershim/src/v8isolate.cc
@@ -35,7 +35,7 @@
 #include "v8isolate.h"
 #include "v8local.h"
 #include "instanceslots.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "mozilla/TimeStamp.h"
 #include "mozilla/ThreadLocal.h"
 

--- a/deps/spidershim/src/v8message.cc
+++ b/deps/spidershim/src/v8message.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include <string>
 

--- a/deps/spidershim/src/v8number.cc
+++ b/deps/spidershim/src/v8number.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "conversions.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/v8numberobject.cc
+++ b/deps/spidershim/src/v8numberobject.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Class.h"
 #include "js/Conversions.h"
 #include "conversions.h"

--- a/deps/spidershim/src/v8object.cc
+++ b/deps/spidershim/src/v8object.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/Proxy.h"
 #include "v8context.h"

--- a/deps/spidershim/src/v8objecttemplate.cc
+++ b/deps/spidershim/src/v8objecttemplate.cc
@@ -22,7 +22,7 @@
 
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "instanceslots.h"
 #include "accessor.h"

--- a/deps/spidershim/src/v8private.cc
+++ b/deps/spidershim/src/v8private.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 
 namespace v8 {
 

--- a/deps/spidershim/src/v8proxy.cc
+++ b/deps/spidershim/src/v8proxy.cc
@@ -22,7 +22,7 @@
 #include "v8conversions.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/Conversions.h"
 #include "js/Proxy.h"

--- a/deps/spidershim/src/v8script.cc
+++ b/deps/spidershim/src/v8script.cc
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/CharacterEncoding.h"
 #include "v8local.h"
 #include "v8string.h"

--- a/deps/spidershim/src/v8scriptcompiler.cc
+++ b/deps/spidershim/src/v8scriptcompiler.cc
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "v8local.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8signature.cc
+++ b/deps/spidershim/src/v8signature.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "conversions.h"
 #include "v8local.h"
 

--- a/deps/spidershim/src/v8stackframe.cc
+++ b/deps/spidershim/src/v8stackframe.cc
@@ -22,7 +22,7 @@
 
 #include "v8.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8stacktrace.cc
+++ b/deps/spidershim/src/v8stacktrace.cc
@@ -25,7 +25,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8string.cc
+++ b/deps/spidershim/src/v8string.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/CharacterEncoding.h"
 #include "mozilla/unused.h"

--- a/deps/spidershim/src/v8stringobject.cc
+++ b/deps/spidershim/src/v8stringobject.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Class.h"
 #include "js/Conversions.h"
 #include "conversions.h"

--- a/deps/spidershim/src/v8template.cc
+++ b/deps/spidershim/src/v8template.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "conversions.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "accessor.h"
 #include "v8local.h"

--- a/deps/spidershim/src/v8trycatch.cc
+++ b/deps/spidershim/src/v8trycatch.cc
@@ -25,7 +25,7 @@
 #include "v8local.h"
 #include "v8isolate.h"
 #include "v8trycatch.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8typedarray.cc
+++ b/deps/spidershim/src/v8typedarray.cc
@@ -21,7 +21,7 @@
 #include "v8.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8uint32.cc
+++ b/deps/spidershim/src/v8uint32.cc
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "v8local.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8unboundscript.cc
+++ b/deps/spidershim/src/v8unboundscript.cc
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "v8.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "v8local.h"
 #include "mozilla/UniquePtr.h"
 

--- a/deps/spidershim/src/v8v8.cc
+++ b/deps/spidershim/src/v8v8.cc
@@ -23,7 +23,7 @@
 #include "v8.h"
 #include "v8handlescope.h"
 #include "v8isolate.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "js/Initialization.h"
 
 namespace v8 {

--- a/deps/spidershim/src/v8value.cc
+++ b/deps/spidershim/src/v8value.cc
@@ -22,7 +22,7 @@
 #include "v8conversions.h"
 #include "conversions.h"
 #include "v8local.h"
-#include "jsapi.h"
+#include "autojsapi.h"
 #include "jsfriendapi.h"
 #include "js/Conversions.h"
 #include "js/Proxy.h"


### PR DESCRIPTION
Per conversation on IRC with @ehsan:
- rename deps/spidershim/src/jsapi.h to autojsapi.h
- `#include "jsapi.h"` -> `#include "autojsapi.h"` in deps/spidershim/src/*
- `#include_next <jsapi.h>` -> `#include <jsapi.h>` in autojsapi.h
