### PR TITLE
get closer to building SpiderMonkey on Windows

### DIFF
--- a/deps/spidershim/scripts/build-spidermonkey.sh
+++ b/deps/spidershim/scripts/build-spidermonkey.sh
@@ -2,7 +2,7 @@
 
 source `dirname "$0"`/travis.sh
 
-for ac in "$AUTOCONF" autoconf213 autoconf2.13; do
+for ac in "$AUTOCONF" autoconf213 autoconf2.13 autoconf-2.13; do
   if which $ac >/dev/null; then
     AUTOCONF=`which $ac`
     break
@@ -46,9 +46,13 @@ test -d $build || mkdir $build
 cd $build
 
 if [ "$TRAVIS" == "true" ]; then
-make="travis_wait 60 make -s"
+  make="travis_wait 60 make -s"
 else
-make="make -s"
+  if [ "$OSTYPE" == "msys" ]; then
+    make="mozmake -s"
+  else
+    make="make -s"
+  fi
 fi
 
 ccache_arg=""


### PR DESCRIPTION
@ehsan These two minor fixes to build-spidermonkey.sh get us a bit closer to building on Windows, although there's more work to do.
