### PR TITLE
also set OTHER_LDFLAGS for Xcode on Mac; link debug build against debug binaries (fixes #197)

### DIFF
--- a/configure
+++ b/configure
@@ -967,6 +967,8 @@ def configure_spidermonkey(o):
       raise Exception('--with-external-spidermonkey-debug passed without specifying --with-external-spidermonkey-release')
   if sm_debug != "":
     o['variables']['external_spidermonkey_debug'] = options.external_spidermonkey_debug
+  else:
+    o['variables']['external_spidermonkey_debug'] = options.external_spidermonkey_release
   o['variables']['external_spidermonkey_release'] = options.external_spidermonkey_release
 
 

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -112,6 +112,7 @@
               ['external_spidermonkey_release_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
                 'ldflags': [ '-lnspr4' ],
+                'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
               }],
             ],
           },
@@ -125,6 +126,7 @@
               ['external_spidermonkey_debug_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
                 'ldflags': [ '-lnspr4' ],
+                'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
               }],
             ],
           },

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -1,9 +1,9 @@
 {
   'variables': {
-    'external_spidermonkey_debug%': '<(external_spidermonkey_release)',
+    'external_spidermonkey_debug': '<(external_spidermonkey_release)',
     'spidermonkey_binaries_debug': [
-      '<(external_spidermonkey_debug%)/js/src/<(STATIC_LIB_PREFIX)js_static<(STATIC_LIB_SUFFIX)',
-      '<(external_spidermonkey_debug%)/config/external/icu/data/icudata.o',
+      '<(external_spidermonkey_debug)/js/src/<(STATIC_LIB_PREFIX)js_static<(STATIC_LIB_SUFFIX)',
+      '<(external_spidermonkey_debug)/config/external/icu/data/icudata.o',
     ],
     'spidermonkey_binaries_release': [
       '<(external_spidermonkey_release)/js/src/<(STATIC_LIB_PREFIX)js_static<(STATIC_LIB_SUFFIX)',
@@ -12,7 +12,7 @@
     'conditions': [
       ['external_spidermonkey_debug_has_nss == 1', {
         'spidermonkey_binaries_debug': [
-          '<(external_spidermonkey_debug%)/dist/lib/<(SHARED_LIB_PREFIX)nss3<(SHARED_LIB_SUFFIX)',
+          '<(external_spidermonkey_debug)/dist/lib/<(SHARED_LIB_PREFIX)nss3<(SHARED_LIB_SUFFIX)',
         ],
       }],
       ['external_spidermonkey_release_has_nss == 1', {
@@ -22,7 +22,7 @@
       }],
       ['OS == "linux"', {
         'spidermonkey_binaries_debug+': [
-          '<(external_spidermonkey_debug%)/mozglue/build/<(STATIC_LIB_PREFIX)mozglue<(STATIC_LIB_SUFFIX)',
+          '<(external_spidermonkey_debug)/mozglue/build/<(STATIC_LIB_PREFIX)mozglue<(STATIC_LIB_SUFFIX)',
         ],
         'spidermonkey_binaries_release+': [
           '<(external_spidermonkey_release)/mozglue/build/<(STATIC_LIB_PREFIX)mozglue<(STATIC_LIB_SUFFIX)',
@@ -30,7 +30,7 @@
       }],
       ['OS == "linux" and external_spidermonkey_debug_has_nspr == 1', {
         'spidermonkey_binaries_debug+': [
-          '<(external_spidermonkey_debug%)/config/external/nspr/pr/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
+          '<(external_spidermonkey_debug)/config/external/nspr/pr/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
         ],
       }],
       ['OS == "linux" and external_spidermonkey_release_has_nspr == 1', {
@@ -40,7 +40,7 @@
       }],
       ['OS == "mac"', {
         'spidermonkey_binaries_debug': [
-          '<(external_spidermonkey_debug%)/dist/bin/<(SHARED_LIB_PREFIX)mozglue<(SHARED_LIB_SUFFIX)',
+          '<(external_spidermonkey_debug)/dist/bin/<(SHARED_LIB_PREFIX)mozglue<(SHARED_LIB_SUFFIX)',
         ],
         'spidermonkey_binaries_release': [
           '<(external_spidermonkey_release)/dist/bin/<(SHARED_LIB_PREFIX)mozglue<(SHARED_LIB_SUFFIX)',
@@ -48,7 +48,7 @@
       }],
       ['OS == "mac" and external_spidermonkey_debug_has_nspr == 1', {
         'spidermonkey_binaries_debug': [
-          '<(external_spidermonkey_debug%)/dist/lib/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
+          '<(external_spidermonkey_debug)/dist/lib/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
         ],
       }],
       ['OS == "mac" and external_spidermonkey_release_has_nspr == 1', {

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -1,6 +1,5 @@
 {
   'variables': {
-    'external_spidermonkey_debug': '<(external_spidermonkey_release)',
     'spidermonkey_binaries_debug': [
       '<(external_spidermonkey_debug)/js/src/<(STATIC_LIB_PREFIX)js_static<(STATIC_LIB_SUFFIX)',
       '<(external_spidermonkey_debug)/config/external/icu/data/icudata.o',


### PR DESCRIPTION
This is needed to link against an external SpiderMonkey build from mozilla-central/gecko-dev. (Unsure why it isn't needed when the "external" build is the internal one like in the Travis tests.)
