### PR TITLE
WIP: copy binaries to PRODUCT_DIR/ rather than PRODUCT_DIR/spidermonkey/CONFIGURATION/ (fixes #194)

### DIFF
--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -112,6 +112,7 @@
               ['external_spidermonkey_release_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
                 'ldflags': [ '-lnspr4' ],
+                'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
               }],
             ],
           },
@@ -125,6 +126,7 @@
               ['external_spidermonkey_debug_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
                 'ldflags': [ '-lnspr4' ],
+                'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
               }],
             ],
           },

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -91,11 +91,11 @@
 
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/spidermonkey/Debug',
+          'destination': '<(PRODUCT_DIR)',
           'files': [ '<@(spidermonkey_binaries_debug)' ],
         },
         {
-          'destination': '<(PRODUCT_DIR)/spidermonkey/Release',
+          'destination': '<(PRODUCT_DIR)',
           'files': [ '<@(spidermonkey_binaries_release)' ],
         },
       ],
@@ -106,8 +106,8 @@
             'defines': ['NDEBUG'],
             'library_dirs': [ '<(PRODUCT_DIR)/spidermonkey/Release' ],
             'include_dirs': [ '<(PRODUCT_DIR)/spidermonkey/Release/dist/include', ],
-            'ldflags':      [ '<(PRODUCT_DIR)/spidermonkey/Release/icudata.o', ],
-            'xcode_settings': {'OTHER_LDFLAGS': ['<(PRODUCT_DIR)/spidermonkey/Release/icudata.o']},
+            'ldflags':      [ '<(PRODUCT_DIR)/icudata.o', ],
+            'xcode_settings': {'OTHER_LDFLAGS': ['<(PRODUCT_DIR)/icudata.o']},
             'conditions': [
               ['external_spidermonkey_release_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
@@ -120,8 +120,8 @@
             'defines': ['DEBUG'],
             'library_dirs': [ '<(PRODUCT_DIR)/spidermonkey/Debug' ],
             'include_dirs': [ '<(PRODUCT_DIR)/spidermonkey/Debug/dist/include', ],
-            'ldflags':      [ '<(PRODUCT_DIR)/spidermonkey/Debug/icudata.o', ],
-            'xcode_settings': {'OTHER_LDFLAGS': ['<(PRODUCT_DIR)/spidermonkey/Debug/icudata.o']},
+            'ldflags':      [ '<(PRODUCT_DIR)/icudata.o', ],
+            'xcode_settings': {'OTHER_LDFLAGS': ['<(PRODUCT_DIR)/icudata.o']},
             'conditions': [
               ['external_spidermonkey_debug_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.


### PR DESCRIPTION
This change fixes #194. But I'm not sure it's the right fix. I still don't quite understand spidermonkey-external.gyp, which seems to segregate external SpiderMonkey build artifacts into configuration-specific subdirectories within _<(PRODUCT_DIR)/spidermonkey/_, i.e. _<(PRODUCT_DIR)/spidermonkey/Release/_ and _<(PRODUCT_DIR)/spidermonkey/Debug/_, even though _<(PRODUCT_DIR)_ is itself already configuration-specific (it's either _out/Release/_ or _out/Debug/_, depending on configuration).
