### PR TITLE
force dist/include symlinks to be recreated

### DIFF
--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -72,7 +72,7 @@
             '<(PRODUCT_DIR)/spidermonkey/Debug/dist/include',
           ],
           'action': [
-            'ln', '-s', '<(external_spidermonkey_debug)/dist/include',
+            'ln', '-fs', '<(external_spidermonkey_debug)/dist/include',
             '<(PRODUCT_DIR)/spidermonkey/Debug/dist/include'
           ],
         },
@@ -83,7 +83,7 @@
             '<(PRODUCT_DIR)/spidermonkey/Release/dist/include',
           ],
           'action': [
-            'ln', '-s', '<(external_spidermonkey_release)/dist/include',
+            'ln', '-fs', '<(external_spidermonkey_release)/dist/include',
             '<(PRODUCT_DIR)/spidermonkey/Release/dist/include'
           ],
         },


### PR DESCRIPTION
The dist/include symlinks need to be force created in order to recreate them when rebuilding. Otherwise, changes to their dependencies cause rebuilding to fail with the _ls_ error "File exists", f.e.:

``` bash
> make -j8
> …
> touch /Users/myk/Projects/gecko-dev/obj-spidermonkey-for-spidershim-debug
> make -j8
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C out BUILDTYPE=Release V=1
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C out BUILDTYPE=Debug V=1
  LD_LIBRARY_PATH=/Users/myk/Projects/spidernode/out/Debug/lib.host:/Users/myk/Projects/spidernode/out/Debug/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/spidershim; mkdir -p /Users/myk/Projects/spidernode/out/Debug/spidermonkey/Debug/dist; ln -s /Users/myk/Projects/gecko-dev/obj-spidermonkey-for-spidershim-debug/dist/include "/Users/myk/Projects/spidernode/out/Debug/spidermonkey/Debug/dist/include"
  LD_LIBRARY_PATH=/Users/myk/Projects/spidernode/out/Release/lib.host:/Users/myk/Projects/spidernode/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/spidershim; mkdir -p /Users/myk/Projects/spidernode/out/Release/spidermonkey/Debug/dist; ln -s /Users/myk/Projects/gecko-dev/obj-spidermonkey-for-spidershim-debug/dist/include "/Users/myk/Projects/spidernode/out/Release/spidermonkey/Debug/dist/include"
ln: /Users/myk/Projects/spidernode/out/Debug/spidermonkey/Debug/dist/include/include: File exists
make[1]: *** [/Users/myk/Projects/spidernode/out/Debug/spidermonkey/Debug/dist/include] Error 1
make: *** [node_g] Error 2
make: *** Waiting for unfinished jobs....
ln: /Users/myk/Projects/spidernode/out/Release/spidermonkey/Debug/dist/include/include: File exists
make[1]: *** [/Users/myk/Projects/spidernode/out/Release/spidermonkey/Debug/dist/include] Error 1
make: *** [node] Error 2
```
