### PR TITLE
explain how to run Node executable built against out-of-tree SpiderMonkey (fixes #194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,18 @@ Where `options` is zero or more of:
 * `--engine`: The JavaScript engine to use.  The default engine is `spidermonkey`.
 * `--debug`: Also build in debug mode.  The default build configuration is release.
 * `--enable-gczeal`: Enable SpiderMonkey gc-zeal support.  This is useful for debugging GC rooting correctness issues.
-* `--with-external-spidermonkey-release` and `--with-external-spidermonkey-debug`: Enable building against an out of tree SpiderMonkey. Expects a path to a built SpiderMonkey object directory (in release and debug modes, respectively)
+* `--with-external-spidermonkey-release` and `--with-external-spidermonkey-debug`: Enable building against an out-of-tree SpiderMonkey. Expects a path to a built SpiderMonkey object directory (in release and debug modes, respectively)
+
+If you build against an out-of-tree SpiderMonkey, you must include the SpiderMonkey library path in _LD_LIBRARY_PATH_ (_DYLD_LIBRARY_PATH_ on Mac) when running Node, i.e.:
+```bash
+$ LD_LIBRARY_PATH=out/Release/spidermonkey/Release ./node -e 'console.log("hello from " + process.jsEngine)'
+```
+
+The SpiderMonkey library path for a Release build of Node (`out/Release/node`, a.k.a. `./node`) is `out/Release/spidermonkey/Release`, as shown above. The path for a Debug build (`out/Debug/node`, a.k.a. `./node_g`) is `out/Debug/spidermonkey/Debug`, i.e.:
+
+```bash
+$ LD_LIBRARY_PATH=out/Debug/spidermonkey/Debug ./node -e 'console.log("hello from " + process.jsEngine)'
+```
 
 To run the API tests, do:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ LD_LIBRARY_PATH=out/Release/spidermonkey/Release ./node -e 'console.log("hello
 The SpiderMonkey library path for a Release build of Node (`out/Release/node`, a.k.a. `./node`) is `out/Release/spidermonkey/Release`, as shown above. The path for a Debug build (`out/Debug/node`, a.k.a. `./node_g`) is `out/Debug/spidermonkey/Debug`, i.e.:
 
 ```bash
-$ LD_LIBRARY_PATH=out/Debug/spidermonkey/Debug ./node -e 'console.log("hello from " + process.jsEngine)'
+$ LD_LIBRARY_PATH=out/Debug/spidermonkey/Debug ./node_g -e 'console.log("hello from " + process.jsEngine)'
 ```
 
 To run the API tests, do:


### PR DESCRIPTION
@ehsan, this documents how to run a SpiderNode executable built against an out-of-tree SpiderMonkey, per https://github.com/mozilla/spidernode/issues/194#issuecomment-245138159. Documentation-only, no code changes.
