### PR TITLE
link nspr4 via 'libraries' rather than 'ldflags'

### DIFF
--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -124,7 +124,6 @@
             'conditions': [
               ['external_spidermonkey_debug_has_nspr == 1', {
                 # Normally we'd use libraries here, but gyp doesn't allow us.
-                'ldflags': [ '-lnspr4' ],
                 'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
               }],
             ],
@@ -149,6 +148,9 @@
             'libraries': [
               '-lmozglue',
             ],
+          }],
+          ['external_spidermonkey_release_has_nspr == 1 or external_spidermonkey_debug_has_nspr == 1', {
+            'libraries': [ '-lnspr4' ],
           }],
         ],
       },


### PR DESCRIPTION
@ehsan, adding `-lnspr4` to _ldflags_ for an external SpiderMonkey with NSPR doesn't work on my Linux distribution (Ubuntu 14.04 LTS). The linker complains about not finding various PR_\* symbols. I suspect this is because adding the flag via _ldflags_ instead of _libraries_ causes it to appear too early in the linker's command line.

This branch fixes that problem. It has the side-effect of requiring debug/release SpiderMonkey builds to be configured the same way: either both of them have NSPR, or neither of them do. But I've imposed the same constraint in #200, and I think it's a reasonable one.
