### PR TITLE
refine external SpiderMonkey build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,6 +276,7 @@ matrix:
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then docker build -t spidernode -f deps/spidershim/scripts/Dockerfile deps/spidershim/scripts; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew unlink autoconf; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install autoconf213 yasm ccache; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install --with-clang llvm && export PATH="/usr/local/opt/llvm/bin:$PATH"; fi
 after_install:

--- a/configure
+++ b/configure
@@ -452,12 +452,6 @@ parser.add_option('--external-spidermonkey-has-nspr',
     default=False,
     help='the out-of-tree SpiderMonkey builds have a copy of NSPR')
 
-parser.add_option('--external-spidermonkey-has-nss',
-    action='store_true',
-    dest='external_spidermonkey_has_nss',
-    default=False,
-    help='the out-of-tree SpiderMonkey builds have a copy of NSS')
-
 parser.add_option('--engine',
     action='store',
     dest='engine',
@@ -953,7 +947,6 @@ def configure_spidermonkey(o):
     o['variables']['external_spidermonkey_debug'] = options.external_spidermonkey_release
   o['variables']['external_spidermonkey_release'] = options.external_spidermonkey_release
   o['variables']['external_spidermonkey_has_nspr'] = 1 if options.external_spidermonkey_has_nspr else 0
-  o['variables']['external_spidermonkey_has_nss'] = 1 if options.external_spidermonkey_has_nss else 0
 
 
 def configure_openssl(o):

--- a/configure
+++ b/configure
@@ -952,10 +952,8 @@ def configure_spidermonkey(o):
   else:
     o['variables']['external_spidermonkey_debug'] = options.external_spidermonkey_release
   o['variables']['external_spidermonkey_release'] = options.external_spidermonkey_release
-  o['variables']['external_spidermonkey_debug_has_nss'] = 1 if options.external_spidermonkey_has_nss else 0
-  o['variables']['external_spidermonkey_debug_has_nspr'] = 1 if options.external_spidermonkey_has_nspr else 0
-  o['variables']['external_spidermonkey_release_has_nss'] = 1 if options.external_spidermonkey_has_nss else 0
-  o['variables']['external_spidermonkey_release_has_nspr'] = 1 if options.external_spidermonkey_has_nspr else 0
+  o['variables']['external_spidermonkey_has_nspr'] = 1 if options.external_spidermonkey_has_nspr else 0
+  o['variables']['external_spidermonkey_has_nss'] = 1 if options.external_spidermonkey_has_nss else 0
 
 
 def configure_openssl(o):

--- a/configure
+++ b/configure
@@ -447,15 +447,15 @@ parser.add_option('--with-external-spidermonkey-release',
     help='enable linking against an out of tree SpiderMonkey release build')
 
 parser.add_option('--external-spidermonkey-has-nspr',
-    action='store',
+    action='store_true',
     dest='external_spidermonkey_has_nspr',
-    default='',
+    default=False,
     help='the out-of-tree SpiderMonkey builds have a copy of NSPR')
 
 parser.add_option('--external-spidermonkey-has-nss',
-    action='store',
+    action='store_true',
     dest='external_spidermonkey_has_nss',
-    default='',
+    default=False,
     help='the out-of-tree SpiderMonkey builds have a copy of NSS')
 
 parser.add_option('--engine',

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -20,17 +20,10 @@
               '<(external_spidermonkey_release)/config/external/icu/data/icudata.o',
             ]},
             'conditions': [
-              # Normally we'd use libraries here, but gyp doesn't allow us,
-              # so we use ldflags instead.
               ['OS == "linux" and external_spidermonkey_release_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_release)/config/external/nspr/pr',
                 ],
-              }],
-              ['OS == "mac"', {
-                'xcode_settings': { 'OTHER_LDFLAGS': [
-                  '<(external_spidermonkey_release)/dist/bin/<(SHARED_LIB_PREFIX)mozglue<(SHARED_LIB_SUFFIX)',
-                ]},
               }],
               ['OS == "mac" and external_spidermonkey_release_has_nspr == 1', {
                 'library_dirs': [
@@ -54,17 +47,10 @@
               '<(external_spidermonkey_debug)/config/external/icu/data/icudata.o',
             ]},
             'conditions': [
-              # Normally we'd use libraries here, but gyp doesn't allow us,
-              # so we use ldflags instead.
               ['OS == "linux" and external_spidermonkey_debug_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_debug)/config/external/nspr/pr',
                 ],
-              }],
-              ['OS == "mac"', {
-                'xcode_settings': { 'OTHER_LDFLAGS': [
-                  '<(external_spidermonkey_debug)/dist/bin/<(SHARED_LIB_PREFIX)mozglue<(SHARED_LIB_SUFFIX)',
-                ]},
               }],
               ['OS == "mac" and external_spidermonkey_debug_has_nspr == 1', {
                 'library_dirs': [

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -83,6 +83,7 @@
         'libraries': [
           '-ljs_static',
           '-lz',
+          '-lmozglue',
         ],
         'conditions': [
           [ 'target_arch=="arm"', {
@@ -91,13 +92,7 @@
           ['OS == "linux"', {
             'libraries': [
               '-ldl',
-              '-lmozglue',
               '-lrt',
-            ],
-          }],
-          ['OS == "mac"', {
-            'libraries': [
-              '-lmozglue',
             ],
           }],
           ['external_spidermonkey_has_nspr == 1', {

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -26,6 +26,16 @@
                 ],
               }],
               ['OS == "mac" and external_spidermonkey_has_nspr == 1', {
+                # On Mac, MOZ_FOLD_LIBS is defined by default, and NSPR is
+                # folded into NSS, so dist/lib/libnspr4.dylib is just a link
+                # to config/external/nss/libnss3.dylib, and we would be more
+                # precise to specify config/external/nss as the library dir
+                # and -lnss3 as the library.
+                #
+                # But specifying dist/lib and -lnspr4 is simpler and accounts
+                # for the possibility that someone builds external SpiderMonkey
+                # without MOZ_FOLD_LIBS.
+                #
                 'library_dirs': [
                   '<(external_spidermonkey_release)/dist/lib',
                 ],
@@ -53,6 +63,16 @@
                 ],
               }],
               ['OS == "mac" and external_spidermonkey_has_nspr == 1', {
+                # On Mac, MOZ_FOLD_LIBS is defined by default, and NSPR is
+                # folded into NSS, so dist/lib/libnspr4.dylib is just a link
+                # to config/external/nss/libnss3.dylib, and we would be more
+                # precise to specify config/external/nss as the library dir
+                # and -lnss3 as the library.
+                #
+                # But specifying dist/lib and -lnspr4 is simpler and accounts
+                # for the possibility that someone builds external SpiderMonkey
+                # without MOZ_FOLD_LIBS.
+                #
                 'library_dirs': [
                   '<(external_spidermonkey_debug)/dist/lib',
                 ],

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -33,9 +33,9 @@
                 ]},
               }],
               ['OS == "mac" and external_spidermonkey_release_has_nspr == 1', {
-                'xcode_settings': { 'OTHER_LDFLAGS': [
-                  '<(external_spidermonkey_release)/dist/lib/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
-                ]},
+                'library_dirs': [
+                  '<(external_spidermonkey_release)/dist/lib',
+                ],
               }],
             ],
           },
@@ -67,9 +67,9 @@
                 ]},
               }],
               ['OS == "mac" and external_spidermonkey_debug_has_nspr == 1', {
-                'xcode_settings': { 'OTHER_LDFLAGS': [
-                  '<(external_spidermonkey_debug)/dist/lib/<(SHARED_LIB_PREFIX)nspr4<(SHARED_LIB_SUFFIX)',
-                ]},
+                'library_dirs': [
+                  '<(external_spidermonkey_debug)/dist/lib',
+                ],
               }],
             ],
           },
@@ -96,7 +96,6 @@
           }],
           ['external_spidermonkey_release_has_nspr == 1 or external_spidermonkey_debug_has_nspr == 1', {
             'libraries': [ '-lnspr4' ],
-            'xcode_settings': {'OTHER_LDFLAGS': ['-lnspr4']},
           }],
         ],
       },

--- a/deps/spidershim/spidermonkey-external.gyp
+++ b/deps/spidershim/spidermonkey-external.gyp
@@ -20,12 +20,12 @@
               '<(external_spidermonkey_release)/config/external/icu/data/icudata.o',
             ]},
             'conditions': [
-              ['OS == "linux" and external_spidermonkey_release_has_nspr == 1', {
+              ['OS == "linux" and external_spidermonkey_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_release)/config/external/nspr/pr',
                 ],
               }],
-              ['OS == "mac" and external_spidermonkey_release_has_nspr == 1', {
+              ['OS == "mac" and external_spidermonkey_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_release)/dist/lib',
                 ],
@@ -47,12 +47,12 @@
               '<(external_spidermonkey_debug)/config/external/icu/data/icudata.o',
             ]},
             'conditions': [
-              ['OS == "linux" and external_spidermonkey_debug_has_nspr == 1', {
+              ['OS == "linux" and external_spidermonkey_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_debug)/config/external/nspr/pr',
                 ],
               }],
-              ['OS == "mac" and external_spidermonkey_debug_has_nspr == 1', {
+              ['OS == "mac" and external_spidermonkey_has_nspr == 1', {
                 'library_dirs': [
                   '<(external_spidermonkey_debug)/dist/lib',
                 ],
@@ -80,7 +80,7 @@
               '-lmozglue',
             ],
           }],
-          ['external_spidermonkey_release_has_nspr == 1 or external_spidermonkey_debug_has_nspr == 1', {
+          ['external_spidermonkey_has_nspr == 1', {
             'libraries': [ '-lnspr4' ],
           }],
         ],


### PR DESCRIPTION
@ehsan This branch fixes one bug (makes --external-spidermonkey-has-nspr a boolean flag) and refines the external SpiderMonkey build configuration in a variety of ways:
1. Since SpiderNode doesn't actually link NSS, it doesn't need to determine whether or not the external SpiderMonkey build has it, so I removed the `--external-spidermonkey-has-nss` flag.
2. Now that SpiderNode assumes that the debug and release builds of external SpiderMonkey either both have NSPR or neither have it, it isn't necessary to differentiate `external_spidermonkey_debug_has_nspr` from `external_spidermonkey_release_has_nspr`, so I merged them into `external_spidermonkey_has_nspr`.
3. To reduce redundancy, increase consistency, and improve the order of linker settings, I switched the settings for NSPR on Mac from OTHER_LDFLAGS to the combination of a library dir and a library.
4. I removed redundant and unnecessarily conditional settings for mozglue.

So this branch is mostly code removal (plus a big comment that makes it look like it adds more lines than it does).
