### PR TITLE
make Travis IRC notifications terser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -303,6 +303,11 @@ notifications:
       - "irc.mozilla.org#spidernode"
     on_success: always # [always|never|change] # default: always
     on_failure: always # [always|never|change] # default: always
+    template:
+      - "%{repository_slug} - %{commit_subject} - %{result} - %{build_url}"
+    use_notice: true
+    # We can do this if we remove the NO_EXTERNAL_MSGS flag (+n).
+    #skip_join: true
 env:
   global:
     - LANG="en_US.UTF-8"


### PR DESCRIPTION
@tbsaunde I just remembered that Travis's default IRC notifications are very chatty. They're three lines for the notification itself, plus the join and leave lines makes five.

For https://github.com/mozilla/pluotsorbet, we optimized for brevity by using a template that put the essential info on one line. We also set the *use_notice* flag to make the notifications be IRC notices rather than messages (so they're not as disruptive). And we set the *skip_join* flag so the bot doesn't need to join the channel first and then leave it afterward.

This branch does most of those things, except for setting *skip_join*, because the channel is currently set to reject external messages (NO_EXTERNAL_MSGS, i.e. +n). If we can get that changed, then we can do that too. In the meantime, I've added it to the configuration in a comment.
