### PR TITLE
make -j2 on all Mac builds (fixes #210)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,33 +223,33 @@ matrix:
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal MAKE_ARGS=-j4
+      env: BUILD_CONFIG=normal MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true MAKE_ARGS=-j4
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=gczeal MAKE_ARGS=-j4
+      env: BUILD_CONFIG=gczeal MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=gczeal ENABLE_DEBUG=true MAKE_ARGS=-j4
+      env: BUILD_CONFIG=gczeal ENABLE_DEBUG=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j4
+      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j4
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
 
 # Disabled for intermittently failing too many times.
 #    - os: osx
 #      compiler: clang-3.8
 #      osx_image: xcode7.3
-#      env: BUILD_CONFIG=normal ENABLE_ASAN=true MAKE_ARGS=-j4
+#      env: BUILD_CONFIG=normal ENABLE_ASAN=true MAKE_ARGS=-j2
 #      before_install:
 #        - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
 #        - tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
@@ -262,7 +262,7 @@ matrix:
     - os: osx
       compiler: clang-3.8
       osx_image: xcode7.3
-      env: BUILD_CONFIG=normal ENABLE_ASAN=true ENABLE_DEBUG=true MAKE_ARGS=-j4
+      env: BUILD_CONFIG=normal ENABLE_ASAN=true ENABLE_DEBUG=true MAKE_ARGS=-j2
       before_install:
         - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
         - tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -223,11 +223,11 @@ matrix:
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal
+      env: BUILD_CONFIG=normal MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
@@ -235,15 +235,15 @@ matrix:
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=gczeal MAKE_ARGS=-j2 ENABLE_DEBUG=true
+      env: BUILD_CONFIG=gczeal ENABLE_DEBUG=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true
+      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
 
 # Disabled for intermittently failing too many times.
 #    - os: osx
@@ -262,7 +262,7 @@ matrix:
     - os: osx
       compiler: clang-3.8
       osx_image: xcode7.3
-      env: BUILD_CONFIG=normal ENABLE_ASAN=true MAKE_ARGS=-j2 ENABLE_DEBUG=true
+      env: BUILD_CONFIG=normal ENABLE_ASAN=true ENABLE_DEBUG=true MAKE_ARGS=-j2
       before_install:
         - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
         - tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -223,33 +223,33 @@ matrix:
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal MAKE_ARGS=-j2
+      env: BUILD_CONFIG=normal MAKE_ARGS=-j4
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true MAKE_ARGS=-j2
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true MAKE_ARGS=-j4
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=gczeal MAKE_ARGS=-j2
+      env: BUILD_CONFIG=gczeal MAKE_ARGS=-j4
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=gczeal ENABLE_DEBUG=true MAKE_ARGS=-j2
+      env: BUILD_CONFIG=gczeal ENABLE_DEBUG=true MAKE_ARGS=-j4
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
+      env: BUILD_CONFIG=normal EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j4
 
     - os: osx
       compiler: clang
-      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j2
+      env: BUILD_CONFIG=normal ENABLE_DEBUG=true EXTERNAL_SPIDERMONKEY=true MAKE_ARGS=-j4
 
 # Disabled for intermittently failing too many times.
 #    - os: osx
 #      compiler: clang-3.8
 #      osx_image: xcode7.3
-#      env: BUILD_CONFIG=normal ENABLE_ASAN=true MAKE_ARGS=-j2
+#      env: BUILD_CONFIG=normal ENABLE_ASAN=true MAKE_ARGS=-j4
 #      before_install:
 #        - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
 #        - tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
@@ -262,7 +262,7 @@ matrix:
     - os: osx
       compiler: clang-3.8
       osx_image: xcode7.3
-      env: BUILD_CONFIG=normal ENABLE_ASAN=true ENABLE_DEBUG=true MAKE_ARGS=-j2
+      env: BUILD_CONFIG=normal ENABLE_ASAN=true ENABLE_DEBUG=true MAKE_ARGS=-j4
       before_install:
         - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
         - tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz


### PR DESCRIPTION
@tbsaunde All four of the intermittent timeouts I've seen on Mac builds on Travis today have been on builds without `MAKE_FLAGS=-j2`, so I think we should add that flag to all the Mac builds to speed them up. This branch does so.