### PR TITLE
align SpiderShim visibility settings to those of Node (via cares)

### DIFF
--- a/deps/spidershim/spidershim.gyp
+++ b/deps/spidershim/spidershim.gyp
@@ -44,7 +44,11 @@
           ],
         }],
         [ 'OS=="mac" or OS=="ios"', {
-          'xcode_settings': { 'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO' },
+          'xcode_settings': {
+            'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',  # -fvisibility-inlines-hidden
+            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
+            'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO',
+          },
         }, {
           'cflags!': ['-Werror'],
         }],


### PR DESCRIPTION
Mac builds complain *a lot* (thousands of times on release builds, tens of times on debug builds) about "different translation units being compiled with different visibility settings." Here's an example:

> ld: warning: direct access in js::RegExpGetSubstitution(JSContext*, JS::Handle<JSLinearString*>, JS::Handle<JSLinearString*>, unsigned long, JS::Handle<JSObject*>, JS::Handle<JSLinearString*>, unsigned long, JS::MutableHandle<JS::Value>) to global weak symbol JS::StructGCPolicy<JS::GCVector<JS::Value, 0ul, js::TempAllocPolicy> >::trace(JSTracer*, JS::GCVector<JS::Value, 0ul, js::TempAllocPolicy>*, char const*) means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.

It looks like the visibility settings are set in deps/cares/common.gypi, which appears to get applied to Node but not to SpiderShim. The specific settings are the xcode_settings keys *GCC_INLINES_ARE_PRIVATE_EXTERN* and *GCC_SYMBOLS_PRIVATE_EXTERN*, which are set to the string `'YES'`, which causes GYP's xcode_emulation.py script to set the cflags `-fvisibility-inlines-hidden` and `-fvisibility=hidden`, respectively.

This branch adds the same settings to deps/spidershim/spidershim.gyp, which squelches those warnings.
